### PR TITLE
feat: refactor deploy into subcommands and fix bundle and chart options

### DIFF
--- a/cmd/wsm/console.go
+++ b/cmd/wsm/console.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"encoding/base64"
+	b64 "encoding/base64"
+	urlutil "net/url"
 	"os"
 	"os/exec"
 	"runtime"
@@ -41,7 +42,9 @@ func ConsoleCmd() *cobra.Command {
 				panic(err)
 			}
 
-			url := "http://localhost:8082/console/login?password=" + base64.StdEncoding.EncodeToString(pwd)
+			url := "http://localhost:8082/console/login?password=" + urlutil.QueryEscape(
+				b64.StdEncoding.EncodeToString([]byte(pwd)),
+			)
 
 			time.AfterFunc(500*time.Millisecond, func() {
 				_ = openBrowser(url)

--- a/cmd/wsm/deploy.go
+++ b/cmd/wsm/deploy.go
@@ -151,8 +151,8 @@ func DeployCmd() *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().StringVarP(&bundlePath, "bundle", "b", "", "Path to the bundle to deploy with. Cannot be combined with chart.")
-	cmd.PersistentFlags().StringVarP(&chartPath, "chart", "c", "", "Path to W&B helm chart. Cannot be combined with bundle.")
+	cmd.PersistentFlags().StringVarP(&bundlePath, "bundle", "b", "", "Path to the bundle to deploy with.")
+	cmd.PersistentFlags().StringVarP(&chartPath, "chart", "c", "", "Path to W&B helm chart. If provided along with bundle, this will take precedence.")
 	cmd.PersistentFlags().StringVarP(&valuesPath, "values", "v", "", "Values file to apply to the helm chart yaml.")
 	cmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "wandb", "Namespace to deploy into.")
 	cmd.PersistentFlags().BoolVarP(&airgapped, "airgapped", "a", false, "Deploy in airgapped mode.")

--- a/cmd/wsm/deploy.go
+++ b/cmd/wsm/deploy.go
@@ -37,7 +37,7 @@ var operatorCmd = &cobra.Command{
 		fmt.Println("Deploying operator")
 		releaseName := "operator"
 
-		operatorChartPath, err := getChartPath([]string{chartPath, bundlePath}, helm.WandbOperatorChart)
+		operatorChartPath, err := getChartPath([]string{chartPath, bundlePath + "/charts"}, helm.WandbOperatorChart)
 
 		operatorValues := values.Values{}
 		if valuesPath != "" {
@@ -73,7 +73,7 @@ var chartsCmd = &cobra.Command{
 		var wandbChartPath string
 		var err error
 
-		wandbChartPath, err = getChartPath([]string{chartPath, bundlePath}, helm.WandbChart)
+		wandbChartPath, err = getChartPath([]string{chartPath, bundlePath + "/charts"}, helm.WandbChart)
 
 		wandbChartBinary, err := base64EncodeFile(wandbChartPath)
 		if err != nil {
@@ -194,7 +194,7 @@ func getChartPath(searchPaths []string, chart string) (chartPath string, err err
 
 	if len(searchPaths) > 0 {
 		for _, searchPath := range searchPaths {
-			chartPath, err = utils.PathFromDir(searchPath+"/charts", chart)
+			chartPath, err = utils.PathFromDir(searchPath, chart)
 			if chartPath != "" && err == nil {
 				return
 			}

--- a/cmd/wsm/deploy.go
+++ b/cmd/wsm/deploy.go
@@ -2,20 +2,19 @@ package main
 
 import (
 	"encoding/base64"
-	"encoding/json"
-	"errors"
 	"fmt"
+	"github.com/pkg/errors"
+	"github.com/wandb/wsm/pkg/crd"
+	"github.com/wandb/wsm/pkg/deployer"
+	"github.com/wandb/wsm/pkg/utils"
 	"os"
 	"path"
 
 	"github.com/spf13/cobra"
-	"github.com/wandb/wsm/pkg/crd"
-	"github.com/wandb/wsm/pkg/deployer"
 	"github.com/wandb/wsm/pkg/helm"
 	"github.com/wandb/wsm/pkg/helm/values"
 	"github.com/wandb/wsm/pkg/kubectl"
 	"github.com/wandb/wsm/pkg/spec"
-	"github.com/wandb/wsm/pkg/utils"
 	"gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
@@ -23,6 +22,186 @@ import (
 
 func init() {
 	rootCmd.AddCommand(DeployCmd())
+}
+
+var bundlePath string
+var chartPath string
+var namespace string
+var valuesPath string
+var airgapped bool
+var temporaryDirectory string
+
+var operatorCmd = &cobra.Command{
+	Use: "operator",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Deploying operator")
+		releaseName := "operator"
+
+		operatorChartPath, err := getChartPath([]string{chartPath, bundlePath}, helm.WandbOperatorChart)
+
+		operatorValues := values.Values{}
+		if valuesPath != "" {
+			if _, err := os.Stat(valuesPath); os.IsNotExist(err) {
+				fmt.Printf("Values file %s does not exist\n", valuesPath)
+				os.Exit(1)
+			}
+		}
+
+		if localVals, err := values.FromYAMLFile(valuesPath); err == nil {
+			if _, ok := localVals["wandb"]; ok {
+				if operatorValsMap, ok := localVals["operator"]; ok {
+					operatorValues = operatorValsMap.(map[string]interface{})
+				}
+			}
+
+		}
+
+		if airgapped {
+			_ = operatorValues.SetValue("airgapped", true)
+		}
+
+		operatorChart := loadChart(operatorChartPath)
+		_, err = helm.Apply(namespace, releaseName, operatorChart, operatorValues.AsMap())
+		if err != nil {
+			fmt.Printf("Error deploying operator: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+var chartsCmd = &cobra.Command{
+	Use: "chart-cm",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Deploying charts")
+		var wandbChartPath string
+		var err error
+
+		wandbChartPath, err = getChartPath([]string{chartPath, bundlePath}, helm.WandbChart)
+
+		wandbChartBinary, err := base64EncodeFile(wandbChartPath)
+		if err != nil {
+			panic(err)
+		}
+
+		err = kubectl.UpsertConfigMap(map[string]string{
+			helm.WandbChart: wandbChartBinary,
+		}, "wandb-charts", namespace)
+		if err != nil {
+			panic(fmt.Sprintf("Error upserting config map: %v", err))
+		}
+	},
+}
+
+var wandbCRCmd = &cobra.Command{
+	Use: "wandb-cr",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Deploying W&B CR")
+
+		getSpec := func() (*spec.Spec, error) {
+			if bundlePath != "" {
+				return specFromBundle(bundlePath)
+			}
+			return deployer.GetChannelSpec("")
+		}
+
+		specToApply, err := getSpec()
+		if err != nil {
+			fmt.Println("Error getting spec:", err)
+			os.Exit(1)
+		}
+
+		vals := specToApply.Values
+		if valuesPath != "" {
+			if _, err := os.Stat(valuesPath); os.IsNotExist(err) {
+				fmt.Printf("Values file %s does not exist\n", valuesPath)
+				os.Exit(1)
+			}
+		}
+
+		if localVals, err := values.FromYAMLFile(valuesPath); err == nil {
+			if _, ok := localVals["wandb"]; ok {
+				vals, err = values.Values(localVals["wandb"].(map[string]interface{})).Merge(vals)
+				if err != nil {
+					fmt.Println("Error merging values:", err)
+					os.Exit(1)
+				}
+			}
+		}
+
+		helmChart := getChart(airgapped, helm.WandbChart, specToApply)
+		wb := crd.NewWeightsAndBiases(helmChart, vals)
+
+		fmt.Println("Applying weights and biases crd")
+		if err := crd.ApplyWeightsAndBiases(wb); err != nil {
+			fmt.Println("Error applying weightsandbiases:", err)
+			fmt.Println("wandb-cr:", wb)
+			os.Exit(1)
+		}
+
+		fmt.Println("Weights and Biases crd applied, finish setting up your instance by running `wsm console`")
+	},
+}
+
+func DeployCmd() *cobra.Command {
+	//releaseName := "wandb"
+	//var operatorChartPath string
+
+	cmd := &cobra.Command{
+		Use: "deploy",
+		Run: func(cmd *cobra.Command, args []string) {
+			if airgapped {
+				chartsCmd.Run(cmd, args)
+			}
+			operatorCmd.Run(cmd, args)
+			wandbCRCmd.Run(cmd, args)
+		},
+	}
+
+	cmd.PersistentFlags().StringVarP(&bundlePath, "bundle", "b", "", "Path to the bundle to deploy with. Cannot be combined with chart.")
+	cmd.PersistentFlags().StringVarP(&chartPath, "chart", "c", "", "Path to W&B helm chart. Cannot be combined with bundle.")
+	cmd.PersistentFlags().StringVarP(&valuesPath, "values", "v", "", "Values file to apply to the helm chart yaml.")
+	cmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "wandb", "Namespace to deploy into.")
+	cmd.PersistentFlags().BoolVarP(&airgapped, "airgapped", "a", false, "Deploy in airgapped mode.")
+
+	cmd.AddCommand(operatorCmd)
+	cmd.AddCommand(chartsCmd)
+	cmd.AddCommand(wandbCRCmd)
+
+	return cmd
+}
+
+func getChartPath(searchPaths []string, chart string) (chartPath string, err error) {
+	tmpDir := getTmpDir()
+
+	if len(searchPaths) > 0 {
+		for _, searchPath := range searchPaths {
+			chartPath, err = utils.PathFromDir(searchPath+"/charts", chart)
+			if chartPath != "" && err == nil {
+				return
+			}
+		}
+		if chartPath == "" {
+			err = errors.New(fmt.Sprintf("Error finding %s chart in search paths: %v", chart, searchPaths))
+		}
+	} else {
+		chartPath, err = utils.PathFromDir(tmpDir, chart)
+		if err != nil {
+			chartPath = downloadHelmChart(helm.WandbHelmRepoURL, chart, "", tmpDir)
+		}
+	}
+
+	return
+}
+
+func getTmpDir() string {
+	if temporaryDirectory == "" {
+		var err error
+		temporaryDirectory, err = os.MkdirTemp(os.TempDir(), "wsm")
+		if err != nil {
+			panic(err)
+		}
+	}
+	return temporaryDirectory
 }
 
 func base64EncodeFile(filePath string) (string, error) {
@@ -35,12 +214,7 @@ func base64EncodeFile(filePath string) (string, error) {
 	return base64.StdEncoding.EncodeToString(fileContents), nil
 }
 
-func downloadHelmChart(
-	url string,
-	name string,
-	version string,
-	dest string,
-) string {
+func downloadHelmChart(url string, name string, version string, dest string) string {
 	helmChart, err := helm.DownloadChart(
 		url,
 		name,
@@ -61,45 +235,6 @@ func loadChart(chartPath string) *chart.Chart {
 	return helmChart
 }
 
-func deployOperator(chartsDir string, wandbChartPath string, operatorChartPath string, operatorValues values.Values, namespace string, releaseName string, airgapped bool) error {
-	fmt.Println("Deploying operator")
-	if operatorChartPath == "" {
-		operatorChartPath = downloadHelmChart(
-			helm.WandbHelmRepoURL, helm.WandbOperatorChart, "", chartsDir,
-		)
-	}
-
-	operatorChart := loadChart(operatorChartPath)
-	if operatorChart == nil {
-		return errors.New("could not find operator chart")
-	}
-
-	if airgapped {
-		_ = operatorValues.SetValue("airgapped", true)
-
-		if wandbChartPath == "" {
-			wandbChartPath = downloadHelmChart(
-				helm.WandbHelmRepoURL, helm.WandbChart, "", chartsDir,
-			)
-		}
-
-		wandbChartBinary, err := base64EncodeFile(wandbChartPath)
-		if err != nil {
-			return err
-		}
-
-		err = kubectl.UpsertConfigMap(map[string]string{
-			helm.WandbChart: wandbChartBinary,
-		}, "wandb-charts", namespace)
-		if err != nil {
-			panic(fmt.Sprintf("Error upserting config map: %v", err))
-		}
-	}
-
-	_, err := helm.Apply(namespace, releaseName, operatorChart, operatorValues.AsMap())
-	return err
-}
-
 func specFromBundle(bundlePath string) (*spec.Spec, error) {
 	specPath := path.Join(bundlePath, "spec.yaml")
 	specData, err := os.ReadFile(specPath)
@@ -115,153 +250,13 @@ func specFromBundle(bundlePath string) (*spec.Spec, error) {
 	return wandbSpec, nil
 }
 
-type LocalSpec struct {
-	Chart struct {
-		Path string `json:"path" yaml:"path"`
-	} `json:"chart" yaml:"chart"`
-	Values values.Values `json:"values" yaml:"values"`
-}
-
 func getChart(airgapped bool, chartPath string, specToApply *spec.Spec) spec.Chart {
 	if airgapped {
-		return spec.Chart{Path: chartPath}
+		return spec.Chart{Path: "/charts/" + chartPath}
 	}
 	return spec.Chart{
 		URL:     specToApply.Chart.URL,
 		Version: specToApply.Chart.Version,
 		Name:    specToApply.Chart.Name,
 	}
-}
-
-func DeployCmd() *cobra.Command {
-	var deployWithHelm bool
-	var bundlePath string
-	var namespace string
-	releaseName := "wandb"
-	var valuesPath string
-	var chartPath string
-	var operatorChartPath string
-	var airgapped bool
-
-	cmd := &cobra.Command{
-		Use: "deploy",
-		Run: func(cmd *cobra.Command, args []string) {
-			homedir, err := os.UserHomeDir()
-			if err != nil {
-				fmt.Printf("could not find home dir: %v", err)
-				os.Exit(1)
-			}
-
-			getSpec := func() (*spec.Spec, error) {
-				if bundlePath != "" {
-					return specFromBundle(bundlePath)
-				}
-				return deployer.GetChannelSpec("")
-			}
-
-			specToApply, err := getSpec()
-			if err != nil {
-				fmt.Println("Error getting spec:", err)
-				os.Exit(1)
-			}
-
-			if bundlePath != "" {
-				if _, err := os.Stat(bundlePath); os.IsNotExist(err) {
-					fmt.Printf("Bundle path %s does not exist\n", bundlePath)
-					os.Exit(1)
-				}
-
-				chartPath, err = utils.PathFromDir(bundlePath+"/charts", helm.WandbChart)
-				if err != nil {
-					fmt.Println("Error finding wandb chart:", err)
-					os.Exit(1)
-				}
-
-				operatorChartPath, err = utils.PathFromDir(bundlePath+"/charts", helm.WandbOperatorChart)
-				if err != nil {
-					fmt.Println("Error finding operator chart:", err)
-					os.Exit(1)
-				}
-			}
-
-			chartsDir := path.Join(homedir, ".wandb", "charts")
-			_ = os.MkdirAll(chartsDir, 0755)
-
-			vals := specToApply.Values
-			operatorVals := values.Values{}
-			if valuesPath != "" {
-				if _, err := os.Stat(valuesPath); os.IsNotExist(err) {
-					fmt.Printf("Values file %s does not exist\n", valuesPath)
-					os.Exit(1)
-				}
-			}
-
-			if localVals, err := values.FromYAMLFile(valuesPath); err == nil {
-				if _, ok := localVals["wandb"]; ok {
-					vals, err = values.Values(localVals["wandb"].(map[string]interface{})).Merge(vals)
-					if err != nil {
-						fmt.Println("Error merging values:", err)
-						os.Exit(1)
-					}
-
-					if err != nil {
-						fmt.Println("Error merging values:", err)
-						os.Exit(1)
-					}
-				}
-
-				if operatorValsMap, ok := localVals["operator"]; ok {
-					operatorVals = operatorValsMap.(map[string]interface{})
-				}
-			}
-
-			if deployWithHelm {
-				if chartPath == "" {
-					fmt.Println("Downloading W&B chart from", specToApply.Chart.URL)
-					chartPath = downloadHelmChart(
-						specToApply.Chart.URL, specToApply.Chart.Name, specToApply.Chart.Version, chartsDir)
-				}
-				helmChart := loadChart(chartPath)
-				if _, err := json.Marshal(vals.AsMap()); err != nil {
-					panic(err)
-				}
-				fmt.Println("Deploying helm chart")
-				if _, err := helm.Apply(namespace, releaseName, helmChart, vals.AsMap()); err != nil {
-					fmt.Println("Error deploying helm chart:", err)
-					os.Exit(1)
-				}
-
-				fmt.Println("Helm chart deployed, finish setting up your instance by running `wsm console`")
-				os.Exit(0)
-			}
-
-			if err := deployOperator(chartsDir, chartPath, operatorChartPath, operatorVals, namespace, "operator", airgapped); err != nil {
-				fmt.Println("Error deploying operator:", err)
-				os.Exit(1)
-			}
-
-			helmChart := getChart(airgapped, chartPath, specToApply)
-			wb := crd.NewWeightsAndBiases(helmChart, vals)
-
-			fmt.Println("Applying weights and biases crd")
-			if err := crd.ApplyWeightsAndBiases(wb); err != nil {
-				fmt.Println("Error applying weightsandbiases:", err)
-				os.Exit(1)
-			}
-
-			fmt.Println("Weights and Biases crd applied, finish setting up your instance by running `wsm console`")
-			os.Exit(0)
-		},
-	}
-
-	cmd.Flags().BoolVarP(&deployWithHelm, "helm", "", false, "Deploy the system using the helm (not recommended).")
-	cmd.Flags().StringVarP(&bundlePath, "bundle", "b", "", "Path to the bundle to deploy with.")
-	cmd.Flags().StringVarP(&valuesPath, "values", "v", "", "Values file to apply to the helm chart yaml.")
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "wandb", "Namespace to deploy into.")
-	cmd.Flags().StringVarP(&chartPath, "chart", "c", "", "Path to W&B helm chart.")
-	cmd.Flags().BoolVarP(&airgapped, "airgapped", "a", false, "Deploy in airgapped mode.")
-
-	_ = cmd.Flags().MarkHidden("helm")
-
-	return cmd
 }

--- a/cmd/wsm/download.go
+++ b/cmd/wsm/download.go
@@ -51,6 +51,7 @@ func DownloadCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "download",
 		Run: func(cmd *cobra.Command, args []string) {
+			_ = os.RemoveAll("bundle")
 			fmt.Println("Downloading operator helm chart")
 			operatorImgs, _ := downloadChartImages(
 				helm.WandbHelmRepoURL,

--- a/pkg/helm/download.go
+++ b/pkg/helm/download.go
@@ -18,12 +18,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func DownloadChart(
-	url string,
-	name string,
-	version string,
-	dest string,
-) (string, error) {
+func DownloadChart(url string, name string, version string, dest string) (string, error) {
 	entry := new(repo.Entry)
 	entry.URL = url
 	entry.Name = name


### PR DESCRIPTION
I split the deploy command into 3 subcommands to allow for updating the operator, airgapped wandb chart, and the wandb custom resource separately.

The deploy command itself just runs the three subcommand as appropriate when called directly.

Additionally I reworked the logic for looking for charts in the `charts` and `bundle` directories when provided.

This should address the following JIRA issues:

- https://wandb.atlassian.net/browse/WB-20706
- https://wandb.atlassian.net/browse/WB-20705
- https://wandb.atlassian.net/browse/WB-19454