### PR TITLE
feat:  WSM binary to List Images 

### DIFF
--- a/cmd/wsm/download.go
+++ b/cmd/wsm/download.go
@@ -52,6 +52,12 @@ func DownloadCmd() *cobra.Command {
 		Use: "download",
 		Run: func(cmd *cobra.Command, args []string) {
 			_ = os.RemoveAll("bundle")
+			// Fetch the latest tag for the controller
+			latestTag, err := getLatestWandbTag()
+			if err != nil {
+				fmt.Printf("Error fetching the latest operator-wandb controller tag: %v\n", err)
+				os.Exit(1)
+			}
 			fmt.Println("Downloading operator helm chart")
 			operatorImgs, _ := downloadChartImages(
 				helm.WandbHelmRepoURL,
@@ -59,7 +65,7 @@ func DownloadCmd() *cobra.Command {
 				"", // empty version means latest
 				map[string]interface{}{
 					"image": map[string]interface{}{
-						"tag": "1.10.1",
+						"tag": latestTag,
 					},
 				},
 			)

--- a/cmd/wsm/list.go
+++ b/cmd/wsm/list.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"fmt"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+	"github.com/wandb/wsm/pkg/deployer"
+	"github.com/wandb/wsm/pkg/helm"
+	"github.com/wandb/wsm/pkg/utils"
+)
+
+var (
+	listStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("12")).
+			Bold(true)
+
+	itemStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("10")).
+			PaddingLeft(2)
+
+	footerStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("14")).
+			Bold(true)
+)
+
+type model struct {
+	spinner spinner.Model
+}
+
+func (m model) Init() tea.Cmd {
+	return nil
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	m.spinner, cmd = m.spinner.Update(msg)
+	return m, cmd
+}
+
+func (m model) View() string {
+	return m.spinner.View()
+}
+
+func ListCmd() *cobra.Command {
+	var platform string
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List images required for deployment",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(lipgloss.NewStyle().
+				Bold(true).
+				Foreground(lipgloss.Color("14")).Render("📦 Starting the process to list all images required for deployment..."))
+
+			// Initialize spinner
+			sp := spinner.New()
+			sp.Spinner = spinner.Dot
+			sp.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("5"))
+			m := model{spinner: sp}
+			p := tea.NewProgram(m)
+
+			// Run spinner in a separate goroutine
+			go func() {
+				if err := p.Start(); err != nil {
+					fmt.Println("Error running spinner:", err)
+				}
+			}()
+
+			// Download and list images
+			operatorImgs, _ := downloadChartImages(
+				helm.WandbHelmRepoURL,
+				helm.WandbOperatorChart,
+				"", // empty version means latest
+				map[string]interface{}{
+					"image": map[string]interface{}{
+						"tag": "1.10.1",
+					},
+				},
+			)
+
+			spec, err := deployer.GetChannelSpec("")
+			if err != nil {
+				panic(err)
+			}
+
+			wandbImgs, _ := downloadChartImages(
+				spec.Chart.URL,
+				spec.Chart.Name,
+				spec.Chart.Version,
+				spec.Values,
+			)
+
+			// Stop spinner
+			p.Quit()
+
+			// Print images
+			fmt.Println(listStyle.Render("Operator Images:"))
+			for _, img := range utils.RemoveDuplicates(operatorImgs) {
+				fmt.Println(itemStyle.Render(img))
+			}
+
+			fmt.Println(listStyle.Render("W&B Images:"))
+			for _, img := range utils.RemoveDuplicates(wandbImgs) {
+				fmt.Println(itemStyle.Render(img))
+			}
+
+			fmt.Println(footerStyle.Render("Here are the images required to deploy W&B. Please ensure these images are available in your internal container registry and update the values.yaml accordingly.\n"))
+		},
+	}
+
+	cmd.Flags().StringVarP(&platform, "platform", "p", "linux/amd64", "Platform to list images for")
+
+	return cmd
+}
+
+func init() {
+	rootCmd.AddCommand(ListCmd())
+}

--- a/cmd/wsm/list.go
+++ b/cmd/wsm/list.go
@@ -82,10 +82,9 @@ func getLatestWandbTag() (string, error) {
 	// Sort tags in natural (version) order
 	sort.Strings(tags)
 
-	// If there are not enough tags, return "latest"
+	// If there are not enough tags, return an error
 	if len(tags) < 2 {
-		fmt.Println("Not enough tags found, returning 'latest'")
-		return "latest", nil
+		return "", fmt.Errorf("not enough tags found")
 	}
 
 	// Return the tag just before the last one


### PR DESCRIPTION
```
./wsm list
📦 Starting the process to list all images required for deployment...
Operator Images:
  wandb/controller:1.10.1
W&B Images:
  wandb/local:0.60.0
  quay.io/prometheus-operator/prometheus-config-reloader:v0.67.0
  quay.io/prometheus/prometheus:v2.47.0
  wandb/console:2.12.2
  docker.io/bitnami/redis:7.2.4-debian-12-r9
  otel/opentelemetry-collector-contrib:0.97.0
Here are the images required to deploy W&B. Please ensure these images are available in your internal container registry and update the values.yaml accordingly.

```