### PR TITLE
chore: Create a duplicate spec 

### DIFF
--- a/cmd/wsm/download.go
+++ b/cmd/wsm/download.go
@@ -76,7 +76,7 @@ func DownloadCmd() *cobra.Command {
 			}
 
 			// Create temporary spec to download images
-			dlSpec := spec
+			dlSpec := *spec
 			// Enable weave-trace in the chart values
 			dlSpec.Values["weave-trace"] = map[string]interface{}{
 				"install": true,

--- a/cmd/wsm/download.go
+++ b/cmd/wsm/download.go
@@ -74,7 +74,7 @@ func DownloadCmd() *cobra.Command {
 			if err != nil {
 				panic(err)
 			}
-
+			// Create a copy of the spec to download additional images without writing changes to the filesystem
 			dlSpec, err := deployer.GetChannelSpec("")
 			if err != nil {
 				panic(err)

--- a/cmd/wsm/download.go
+++ b/cmd/wsm/download.go
@@ -75,8 +75,11 @@ func DownloadCmd() *cobra.Command {
 				panic(err)
 			}
 
-			// Create temporary spec to download images
-			dlSpec := *spec
+			dlSpec, err := deployer.GetChannelSpec("")
+			if err != nil {
+				panic(err)
+			}
+
 			// Enable weave-trace in the chart values
 			dlSpec.Values["weave-trace"] = map[string]interface{}{
 				"install": true,

--- a/cmd/wsm/download.go
+++ b/cmd/wsm/download.go
@@ -75,17 +75,19 @@ func DownloadCmd() *cobra.Command {
 				panic(err)
 			}
 
+			// Create temporary spec to download images
+			dlSpec := spec
 			// Enable weave-trace in the chart values
-			spec.Values["weave-trace"] = map[string]interface{}{
+			dlSpec.Values["weave-trace"] = map[string]interface{}{
 				"install": true,
 			}
-			
+
 			fmt.Println("Downloading wandb helm chart")
 			wandbImgs, _ := downloadChartImages(
 				spec.Chart.URL,
 				spec.Chart.Name,
 				spec.Chart.Version,
-				spec.Values,
+				dlSpec.Values,
 			)
 
 			imgs := utils.RemoveDuplicates(append(wandbImgs, operatorImgs...))


### PR DESCRIPTION
Uses duplicate spec to make changes to download list without writing persistent spec changes to disc.