### PR TITLE
feat: use channel version for weave-trace

### DIFF
--- a/cmd/wsm/download.go
+++ b/cmd/wsm/download.go
@@ -58,12 +58,6 @@ func DownloadCmd() *cobra.Command {
 				fmt.Printf("Error fetching the latest operator-wandb controller tag: %v\n", err)
 				os.Exit(1)
 			}
-			// Fetch the latest tag for weave-trace
-			weaveTraceTag, err := getMostRecentTag("wandb/weave-trace")
-			if err != nil {
-				fmt.Printf("Error fetching the latest weave-trace tag: %v\n", err)
-				os.Exit(1)
-			}
 			fmt.Println("Downloading operator helm chart")
 			operatorImgs, _ := downloadChartImages(
 				helm.WandbHelmRepoURL,
@@ -87,11 +81,8 @@ func DownloadCmd() *cobra.Command {
 			}
 
 			// Enable weave-trace in the chart values
-			dlSpec.Values["weave-trace"] = map[string]interface{}{
-				"install": true,
-				"image": map[string]interface{}{
-					"tag": weaveTraceTag,
-				},
+			if dlWeaveTrace, ok := dlSpec.Values["weave-trace"]; ok {
+				dlWeaveTrace.(map[string]interface{})["install"] = true
 			}
 
 			fmt.Println("Downloading wandb helm chart")

--- a/cmd/wsm/list.go
+++ b/cmd/wsm/list.go
@@ -124,12 +124,6 @@ func ListCmd() *cobra.Command {
 				p.Quit()
 				return
 			}
-			weaveTraceTag, err := getMostRecentTag("wandb/weave-trace")
-			if err != nil {
-				fmt.Printf("Error fetching the latest weave-trace tag: %v\n", err)
-				p.Quit()
-				return
-			}
 			operatorImgs, _ := downloadChartImages(
 				helm.WandbHelmRepoURL,
 				helm.WandbOperatorChart,
@@ -147,11 +141,8 @@ func ListCmd() *cobra.Command {
 			}
 
 			// Enable weave-trace in the chart values
-			spec.Values["weave-trace"] = map[string]interface{}{
-				"install": true,
-				"image": map[string]interface{}{
-					"tag": weaveTraceTag,
-				},
+			if weaveTrace, ok := spec.Values["weave-trace"]; ok {
+				weaveTrace.(map[string]interface{})["install"] = true
 			}
 
 			wandbImgs, _ := downloadChartImages(


### PR DESCRIPTION
local tests:
```
✗ go run ./cmd/wsm list    
📦 Starting the process to list all images required for deployment...
Operator Images:
  wandb/controller:1.16.1
W&B Images:
  otel/opentelemetry-collector-contrib:0.97.0
  wandb/local:0.64.1
  wandb/weave-trace:0.64.1
  wandb/console:2.13.3
  quay.io/prometheus-operator/prometheus-config-reloader:v0.67.0
  quay.io/prometheus/prometheus:v2.47.0
  docker.io/bitnami/redis:7.2.4-debian-12-r9
```
after `go run ./cmd/wsm download`:

from `bundle/spec.yaml`
```
    weave-trace:
        image:
            repository: wandb/weave-trace
            tag: 0.64.1
```

from downloaded images:
```
✗ ls bundle/images/wandb 
console:2.13.3     controller:1.16.1  local:0.64.1       weave-trace:0.64.1
```