### PR TITLE
Fix invalid WaitStrategy in DeleteOperator

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -309,7 +309,7 @@ func DeleteOperator(ctx context.Context, namespace string) error {
 	}
 
 	uninstallClient := action.NewUninstall(actionConfig)
-	uninstallClient.WaitStrategy = "hook-only"
+	uninstallClient.WaitStrategy = "hookOnly"
 	uninstallClient.Timeout = 5 * time.Minute
 
 	_, err = uninstallClient.Run(releaseName)


### PR DESCRIPTION
## Summary
- `DeleteOperator` sets `WaitStrategy = "hook-only"` (kebab-case), but Helm v4 expects `"hookOnly"` (camelCase)
- This causes every operator uninstall to fail with: `unknown wait strategy (hook-only). Valid values are: watcher, hookOnly, legacy`
- One-character fix — the install/upgrade paths already use `"hookOnly"` correctly

## Test plan
- [ ] Run `DeleteOperator` against a cluster with the operator installed and confirm uninstall succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)