### PR TITLE
chore(cert-manager): Make cert-manager management optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ wsm deploy-v2 [command] [flags]
 - `operator`: Deploy the v2 operator with specified versions and configuration.
   - `--operator-chart-version string`: Operator Chart version (e.g., v2.0.0) (default "1.5.2").
   - `--operator-namespace string`: Namespace for operator (default "wandb-operators").
+  - `--install-cert-manager`: Cert-manager install mode: `auto` (detect and reuse existing), `true` (force install flow), `false` (skip installation) (default "auto").
   - `--include-cr`: Include the WeightsAndBiases Custom Resource in the operator deployment.
   - `--setup-k8s-cluster`: Setup a Kind cluster before deploying.
   - `--cluster-name string`: Name of the Kind cluster (only used with `--setup-k8s-cluster`) (default "kind").

--- a/cmd/wsm/deploy_v2.go
+++ b/cmd/wsm/deploy_v2.go
@@ -27,6 +27,12 @@ func init() {
 // TODO once an official release publishes a manifest, we should switch to lookup up the most recent non-dev release and not have a default.
 const defaultWandbVersion = "0.78.0-pre.1772047260"
 
+const (
+	certManagerInstallModeAuto  = "auto"
+	certManagerInstallModeTrue  = "true"
+	certManagerInstallModeFalse = "false"
+)
+
 var (
 	wandbCR = &v2.WeightsAndBiases{
 		TypeMeta: metav1.TypeMeta{
@@ -179,6 +185,7 @@ func wandbCreateCmd() *cobra.Command {
 
 func operatorDeployCmd() *cobra.Command {
 	var setupCluster bool
+	var installCertManagerMode string
 	var includeCR bool
 	var clusterName string
 	var workers int
@@ -206,7 +213,7 @@ func operatorDeployCmd() *cobra.Command {
 
 			// Perform the deployment
 			deployStart := time.Now()
-			if err := performDeploy(setupCluster, includeCR, wait, clusterName, workers, operatorChartVersion, wandbVersion, operatorNamespace); err != nil {
+			if err := performDeploy(setupCluster, installCertManagerMode, includeCR, wait, clusterName, workers, operatorChartVersion, wandbVersion, operatorNamespace); err != nil {
 				fmt.Printf("\n✗ Deployment failed: %v\n", err)
 				return err
 			}
@@ -233,16 +240,18 @@ func operatorDeployCmd() *cobra.Command {
 	//cmd.Flags().StringVar(&operatorVersion, "operator-version", "", "Operator image version (e.g., v2.0.0) - defaults to value in the chart")
 	cmd.Flags().StringVar(&operatorChartVersion, "operator-chart-version", "1.5.2", "Operator Chart version (e.g., v2.0.0)")
 	cmd.Flags().StringVar(&operatorNamespace, "operator-namespace", "wandb-operators", "Namespace for operator")
+	cmd.Flags().StringVar(&installCertManagerMode, "install-cert-manager", certManagerInstallModeAuto, "Cert-manager install mode: auto (detect and reuse existing), true (force install flow), false (skip installation)")
 
 	cmd.Flags().BoolVar(&includeCR, "include-cr", false, "Include the Wandb CR in the operator deployment")
 	return cmd
 }
 
-func performDeploy(setupCluster bool, includeCR bool, wait bool, clusterName string, workers int, operatorChartVersion string, wandbVersion string, operatorNamespace string) error {
+func performDeploy(setupCluster bool, installCertManagerMode string, includeCR bool, wait bool, clusterName string, workers int, operatorChartVersion string, wandbVersion string, operatorNamespace string) error {
 	ctx := context.Background()
+	installCertManagerMode = strings.ToLower(strings.TrimSpace(installCertManagerMode))
 
 	// Calculate total steps based on flags
-	totalSteps := 2 // Always: cert-manager, deploy operator, create CR
+	totalSteps := 2 // Always: ensure cert-manager, deploy operator
 	if setupCluster {
 		totalSteps++
 	}
@@ -270,21 +279,42 @@ func performDeploy(setupCluster bool, includeCR bool, wait bool, clusterName str
 		clusterName = ""
 	}
 
-	// Step 2: Install cert-manager
-	fmt.Printf("[%d/%d] Installing cert-manager...", currentStep, totalSteps)
+	// Step 2: Ensure cert-manager
+	fmt.Printf("[%d/%d] Ensuring cert-manager...", currentStep, totalSteps)
 	start := time.Now()
 
-	if err := operator.InstallCertManager(ctx); err != nil {
+	switch installCertManagerMode {
+	case certManagerInstallModeAuto:
+		if err := operator.InstallCertManager(ctx, true); err != nil {
+			fmt.Println(" ✗")
+			return err
+		}
+	case certManagerInstallModeTrue:
+		if err := operator.InstallCertManager(ctx, false); err != nil {
+			fmt.Println(" ✗")
+			return err
+		}
+	case certManagerInstallModeFalse:
+		// Skip installation and only verify cert-manager readiness below.
+	default:
 		fmt.Println(" ✗")
-		return err
+		return fmt.Errorf("invalid --install-cert-manager value %q (expected: auto, true, false)", installCertManagerMode)
 	}
 
 	if err := operator.WaitForCertManager(ctx, 5*time.Minute); err != nil {
 		fmt.Println(" ✗")
+		if installCertManagerMode == certManagerInstallModeFalse {
+			return fmt.Errorf("cert-manager is not ready and installation is disabled (--install-cert-manager=false): %w", err)
+		}
 		return err
 	}
 
-	fmt.Printf(" ✓ (%s)\n", time.Since(start).Round(time.Second))
+	switch {
+	case installCertManagerMode == certManagerInstallModeFalse:
+		fmt.Printf(" ✓ (%s, installation disabled)\n", time.Since(start).Round(time.Second))
+	default:
+		fmt.Printf(" ✓ (%s)\n", time.Since(start).Round(time.Second))
+	}
 	currentStep++
 
 	// Step 3: Create infra-operators wandbNamespace

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -51,28 +51,54 @@ func CreateNamespace(ctx context.Context, namespace string) error {
 	return nil
 }
 
-// InstallCertManager installs cert-manager using kubernetes client
-func InstallCertManager(ctx context.Context) error {
-	const certManagerURL = "https://github.com/cert-manager/cert-manager/releases/download/v1.19.2/cert-manager.yaml"
+const (
+	certManagerNamespace      = "cert-manager"
+	certManagerDeploymentName = "cert-manager"
+	certManagerManifestURL    = "https://github.com/cert-manager/cert-manager/releases/download/v1.19.2/cert-manager.yaml"
+)
 
-	resp, err := http.Get(certManagerURL)
-	if err != nil {
-		return fmt.Errorf("failed to download cert-manager manifest: %w", err)
+// InstallCertManager installs cert-manager.
+// When skipIfPresent is true, installation is skipped if the cert-manager deployment already exists.
+func InstallCertManager(ctx context.Context, skipIfPresent bool) error {
+	if skipIfPresent {
+		deploymentExists, err := certManagerDeploymentExists(ctx)
+		if err != nil {
+			return err
+		}
+		if deploymentExists {
+			return nil
+		}
 	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download cert-manager manifest: status code %d", resp.StatusCode)
+	manifest, err := downloadCertManagerManifest()
+	if err != nil {
+		return err
 	}
 
-	manifest, err := io.ReadAll(resp.Body)
-
-	err = kubectl.ApplyYAML(ctx, manifest)
-	if err != nil {
+	if err := kubectl.ApplyYAML(ctx, manifest); err != nil {
 		return fmt.Errorf("failed to apply cert-manager manifest: %w", err)
 	}
 
 	return nil
+}
+
+func downloadCertManagerManifest() ([]byte, error) {
+	resp, err := http.Get(certManagerManifestURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download cert-manager manifest: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to download cert-manager manifest: status code %d", resp.StatusCode)
+	}
+
+	manifest, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cert-manager manifest: %w", err)
+	}
+
+	return manifest, nil
 }
 
 // WaitForCertManager waits for cert-manager to be ready
@@ -82,47 +108,44 @@ func WaitForCertManager(ctx context.Context, timeout time.Duration) error {
 		return err
 	}
 
-	deployments := []string{"cert-manager", "cert-manager-webhook", "cert-manager-cainjector"}
-
 	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		for _, name := range deployments {
-			deploy, err := cs.AppsV1().Deployments("cert-manager").Get(ctx, name, metav1.GetOptions{})
-			if err != nil {
-				return false, nil
-			}
+		deploy, err := cs.AppsV1().Deployments(certManagerNamespace).Get(ctx, certManagerDeploymentName, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
 
-			isAvailable := false
-			for _, cond := range deploy.Status.Conditions {
-				if cond.Type == "Available" && cond.Status == corev1.ConditionTrue {
-					isAvailable = true
-					break
-				}
-			}
-			if !isAvailable {
-				return false, nil
+		isAvailable := false
+		for _, cond := range deploy.Status.Conditions {
+			if cond.Type == "Available" && cond.Status == corev1.ConditionTrue {
+				isAvailable = true
+				break
 			}
 		}
-		return true, nil
+		return isAvailable, nil
 	})
+}
+
+func certManagerDeploymentExists(ctx context.Context) (bool, error) {
+	_, cs, err := kubectl.GetClientset()
+	if err != nil {
+		return false, err
+	}
+
+	_, err = cs.AppsV1().Deployments(certManagerNamespace).Get(ctx, certManagerDeploymentName, metav1.GetOptions{})
+	if err == nil {
+		return true, nil
+	}
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("failed to check cert-manager deployment %q: %w", certManagerDeploymentName, err)
 }
 
 // DeleteCertManager deletes the cert-manager resources
 func DeleteCertManager(ctx context.Context) error {
-	const manifestURL = "https://github.com/cert-manager/cert-manager/releases/download/v1.19.2/cert-manager.yaml"
-
-	resp, err := http.Get(manifestURL)
+	manifest, err := downloadCertManagerManifest()
 	if err != nil {
-		return fmt.Errorf("failed to download cert-manager manifest for deletion: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("failed to download cert-manager manifest for deletion: status code %d", resp.StatusCode)
-	}
-
-	manifest, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read cert-manager manifest for deletion: %w", err)
+		return fmt.Errorf("failed to prepare cert-manager manifest for deletion: %w", err)
 	}
 
 	// We don't have a DeleteYAML in kubectl, but we can use ApplyYAML with a trick or add DeleteYAML.


### PR DESCRIPTION
This PR allows `wsm` to respect/detect existing `cert-manager` installs on a kubernetes cluster before trying to install it. Additonally adds flags to attempt forcing/or skipping install all together. `cert-manager` is still required, however this deployment now works on clusters with cert manager already installed.

Adds flag `--install-cert-manager` with 3 options: auto (default), true, false

Simplified install API to one function:
- InstallCertManager(ctx, skipIfPresent bool)
- skipIfPresent=true is the default auto behavior.