### PR TITLE
feat(operator): Support all Operator-V2 settings flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ wsm deploy-v2 [command] [flags]
   - `--operator-telemetry-forward-endpoint string`: Forward OTLP telemetry to this endpoint when telemetry mode is `forward`.
   - `--include-cr`: Include the WeightsAndBiases Custom Resource in the operator deployment.
   - `--setup-k8s-cluster`: Setup a Kind cluster before deploying.
+    - When used with `--include-cr` and `--networking-mode ingress`, WSM also installs `ingress-nginx` in the Kind cluster.
   - `--cluster-name string`: Name of the Kind cluster (only used with `--setup-k8s-cluster`) (default "kind").
   - `--workers int`: Number of worker nodes (only used with `--setup-k8s-cluster`).
   - *Accepts all flags listed under `wandb deploy` below (Used with `--include-cr`).*
@@ -120,11 +121,18 @@ wsm deploy-v2 [command] [flags]
     - `--cr-file string`: Path to WeightsAndBiases CR YAML (uses built-in default if not provided).
     - `--license string`: W&B license string (optional, injected into spec.wandb.license).
     - `--license-file string`: Path to W&B license file (optional, injected into spec.wandb.license).
+    - `--hostname string`: Override `spec.wandb.hostname`.
     - `--wandb-name string`: Name of the W&B instance (default "wandb").
     - `--wandb-namespace string`: Namespace for CR (default "wandb").
     - `--wandb-version string`: Server manifest version (e.g., 0.76.1).
     - `--managed-infra-telemetry-enabled[=true|false]`: Set telemetry for all managed infrastructure components.
     - `--mysql-telemetry-enabled`, `--redis-telemetry-enabled`, `--kafka-telemetry-enabled`, `--object-store-telemetry-enabled`, `--clickhouse-telemetry-enabled`: Override telemetry per managed component.
+    - `--networking-mode string`: Set `spec.networking.mode` to `none`, `ingress`, or `gateway`.
+    - `--ingress-class-name string`: Set `spec.networking.ingress.ingressClassName`.
+    - `--networking-annotations key=value,key2=value2`: Set `spec.networking.annotations`.
+    - `--networking-tls-secret-name string`: Set `spec.networking.tls.secretName`.
+    - `--networking-cert-manager-cluster-issuer string`: Set `spec.networking.tls.certManager.clusterIssuer`.
+    - `--networking-cert-manager-issuer string`: Set `spec.networking.tls.certManager.issuer`.
   - `destroy`: Destroy an instance of W&B.
     - `--wandb-name string`: Name of the W&B instance (default "wandb").
     - `--wandb-namespace string`: Namespace for CR (default "wandb").

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ wsm deploy-v2 [command] [flags]
     - Note: The Chart version specified will determine the image tag of operator deployed based on the [values file](https://github.com/wandb/operator/blob/v2/deploy/operator/values.yaml#L11)
   - `--operator-namespace string`: Namespace for operator (default "wandb-operators").
   - `--install-cert-manager`: Cert-manager install mode: `auto` (detect and reuse existing), `true` (force install flow), `false` (skip installation) (default "auto").
+  - `--operator-telemetry-mode string`: Operator chart telemetry mode: `off`, `forward`, or `full`.
+  - `--operator-telemetry-namespace string`: Managed namespace for operator telemetry resources (defaults to the W&B CR namespace).
+  - `--operator-telemetry-otel-secret-name string`: Secret name used for operator-managed telemetry connection settings.
+  - `--operator-telemetry-forward-endpoint string`: Forward OTLP telemetry to this endpoint when telemetry mode is `forward`.
   - `--include-cr`: Include the WeightsAndBiases Custom Resource in the operator deployment.
   - `--setup-k8s-cluster`: Setup a Kind cluster before deploying.
   - `--cluster-name string`: Name of the Kind cluster (only used with `--setup-k8s-cluster`) (default "kind").
@@ -119,6 +123,8 @@ wsm deploy-v2 [command] [flags]
     - `--wandb-name string`: Name of the W&B instance (default "wandb").
     - `--wandb-namespace string`: Namespace for CR (default "wandb").
     - `--wandb-version string`: Server manifest version (e.g., 0.76.1).
+    - `--managed-infra-telemetry-enabled[=true|false]`: Set telemetry for all managed infrastructure components.
+    - `--mysql-telemetry-enabled`, `--redis-telemetry-enabled`, `--kafka-telemetry-enabled`, `--object-store-telemetry-enabled`, `--clickhouse-telemetry-enabled`: Override telemetry per managed component.
   - `destroy`: Destroy an instance of W&B.
     - `--wandb-name string`: Name of the W&B instance (default "wandb").
     - `--wandb-namespace string`: Namespace for CR (default "wandb").

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ wsm deploy-v2 [command] [flags]
   - `--operator-telemetry-mode string`: Operator chart telemetry mode: `off`, `forward`, or `full`.
   - `--operator-telemetry-namespace string`: Managed namespace for operator telemetry resources (defaults to the W&B CR namespace).
   - `--operator-telemetry-otel-secret-name string`: Secret name used for operator-managed telemetry connection settings.
+  - `--operator-telemetry-otel-protocol string`: OTLP protocol for operator-managed telemetry (defaults to `http/protobuf`).
+  - `--operator-telemetry-otel-service-name string`: OTEL service name for operator-managed telemetry (defaults to `wandb-service`).
+  - `--operator-telemetry-otel-resource-attributes string`: OTEL resource attributes for operator-managed telemetry.
   - `--operator-telemetry-forward-endpoint string`: Forward OTLP telemetry to this endpoint when telemetry mode is `forward`.
   - `--include-cr`: Include the WeightsAndBiases Custom Resource in the operator deployment.
   - `--setup-k8s-cluster`: Setup a Kind cluster before deploying.

--- a/cmd/wsm/deploy_v2.go
+++ b/cmd/wsm/deploy_v2.go
@@ -12,11 +12,7 @@ import (
 	"github.com/wandb/wsm/pkg/kind"
 	"github.com/wandb/wsm/pkg/kubectl"
 	"github.com/wandb/wsm/pkg/operator"
-	"gopkg.in/yaml.v3"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/ptr"
-
-	"github.com/wandb/operator/api/v2"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func init() {
@@ -34,41 +30,7 @@ const (
 )
 
 var (
-	wandbCR = &v2.WeightsAndBiases{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "apps.wandb.com/v2",
-			Kind:       "WeightsAndBiases",
-		},
-		Spec: v2.WeightsAndBiasesSpec{
-			Wandb: v2.WandbAppSpec{
-				Hostname: "http://localhost:8080",
-				Features: map[string]bool{"proxy": true},
-				InternalServiceAuth: v2.InternalServiceAuth{
-					Enabled: ptr.Bool(true),
-				},
-			},
-			MySQL: v2.WBMySQLSpec{
-				WBInfraSpec: v2.WBInfraSpec{Enabled: true},
-				Telemetry:   v2.Telemetry{Enabled: true},
-			},
-			Redis: v2.WBRedisSpec{
-				WBInfraSpec: v2.WBInfraSpec{Enabled: true},
-				Telemetry:   v2.Telemetry{Enabled: true},
-			},
-			Kafka: v2.WBKafkaSpec{
-				WBInfraSpec: v2.WBInfraSpec{Enabled: true},
-				Telemetry:   v2.Telemetry{Enabled: true},
-			},
-			Minio: v2.WBMinioSpec{
-				WBInfraSpec: v2.WBInfraSpec{Enabled: true},
-				Telemetry:   v2.Telemetry{Enabled: true},
-			},
-			ClickHouse: v2.WBClickHouseSpec{
-				WBInfraSpec: v2.WBInfraSpec{Enabled: true},
-				Telemetry:   v2.Telemetry{Enabled: true},
-			},
-		},
-	}
+	wandbCR = defaultWandbCR()
 )
 
 // DeployV2Cmd returns the deploy-v2 command with subcommands
@@ -95,6 +57,12 @@ func DeployV2Cmd() *cobra.Command {
 	cmd.PersistentFlags().String("wandb-name", "wandb", "Name of the W&B instance")
 	cmd.PersistentFlags().String("wandb-version", "", "Server manifest version (e.g., 0.76.1)")
 	cmd.PersistentFlags().String("wandb-namespace", "wandb", "Namespace for CR")
+	cmd.PersistentFlags().Bool(flagManagedInfraTelemetryEnabled, false, "Set telemetry.enabled for all managed infrastructure components (use =false to disable)")
+	cmd.PersistentFlags().Bool(flagMySQLTelemetryEnabled, false, "Set spec.mysql managed telemetry.enabled (use =false to disable)")
+	cmd.PersistentFlags().Bool(flagRedisTelemetryEnabled, false, "Set spec.redis managed telemetry.enabled (use =false to disable)")
+	cmd.PersistentFlags().Bool(flagKafkaTelemetryEnabled, false, "Set spec.kafka managed telemetry.enabled (use =false to disable)")
+	cmd.PersistentFlags().Bool(flagObjectStoreTelemetryEnabled, false, "Set spec.objectStore managed telemetry.enabled (use =false to disable)")
+	cmd.PersistentFlags().Bool(flagClickHouseTelemetryEnabled, false, "Set spec.clickhouse managed telemetry.enabled (use =false to disable)")
 	// TODO readd this when the CR reports ready properly
 	//cmd.Flags().Bool("wait", false, "Wait for the W&B instance to be ready (status.ready == true)")
 
@@ -156,7 +124,7 @@ func wandbCreateCmd() *cobra.Command {
 
 			ctx := context.Background()
 
-			err := processWandbCR(crFile, wandbVersion, wandbName, license, licenseFile, wandbNamespace)
+			err := processWandbCR(cmd, crFile, wandbVersion, wandbName, license, licenseFile, wandbNamespace)
 			if err != nil {
 				return err
 			}
@@ -170,7 +138,7 @@ func wandbCreateCmd() *cobra.Command {
 			if wait {
 				fmt.Println("Waiting for W&B instance to be ready...")
 
-				if err := operator.WaitForCRReady(ctx, wandbCR.Namespace, wandbCR.Name, 30*time.Minute); err != nil {
+				if err := operator.WaitForCRReady(ctx, wandbCR.GetNamespace(), wandbCR.GetName(), 30*time.Minute); err != nil {
 					fmt.Println(" ✗")
 					return err
 				}
@@ -192,6 +160,7 @@ func operatorDeployCmd() *cobra.Command {
 	//var operatorVersion string
 	var operatorChartVersion string
 	var operatorNamespace string
+	var operatorReleaseValues map[string]interface{}
 
 	cmd := &cobra.Command{
 		Use:   "operator",
@@ -206,14 +175,24 @@ func operatorDeployCmd() *cobra.Command {
 			wandbName, _ := cmd.Flags().GetString("wandb-name")
 			wait, _ := cmd.Flags().GetBool("wait")
 
-			err := processWandbCR(crFile, wandbVersion, wandbName, license, licenseFile, wandbNamespace)
+			err := processWandbCR(cmd, crFile, wandbVersion, wandbName, license, licenseFile, wandbNamespace)
+			if err != nil {
+				return err
+			}
+
+			telemetryOverrides, err := extractOperatorTelemetryOverrides(cmd)
+			if err != nil {
+				return err
+			}
+
+			operatorReleaseValues, err = buildOperatorReleaseValues(wandbCR.GetNamespace(), telemetryOverrides)
 			if err != nil {
 				return err
 			}
 
 			// Perform the deployment
 			deployStart := time.Now()
-			if err := performDeploy(setupCluster, installCertManagerMode, includeCR, wait, clusterName, workers, operatorChartVersion, wandbVersion, operatorNamespace); err != nil {
+			if err := performDeploy(setupCluster, installCertManagerMode, includeCR, wait, clusterName, workers, operatorChartVersion, operatorNamespace, operatorReleaseValues); err != nil {
 				fmt.Printf("\n✗ Deployment failed: %v\n", err)
 				return err
 			}
@@ -225,8 +204,8 @@ func operatorDeployCmd() *cobra.Command {
 			if setupCluster {
 				fmt.Printf("  • Kubectl context: kind-%s\n", clusterName)
 			}
-			fmt.Printf("  • Namespace: %s\n", wandbNamespace)
-			fmt.Printf("  • Status: kubectl get wandb -n %s\n", wandbNamespace)
+			fmt.Printf("  • Namespace: %s\n", wandbCR.GetNamespace())
+			fmt.Printf("  • Status: kubectl get wandb -n %s\n", wandbCR.GetNamespace())
 			fmt.Println()
 			return nil
 		},
@@ -241,12 +220,19 @@ func operatorDeployCmd() *cobra.Command {
 	cmd.Flags().StringVar(&operatorChartVersion, "operator-chart-version", "1.5.2", "Operator Chart version (e.g., v2.0.0)")
 	cmd.Flags().StringVar(&operatorNamespace, "operator-namespace", "wandb-operators", "Namespace for operator")
 	cmd.Flags().StringVar(&installCertManagerMode, "install-cert-manager", certManagerInstallModeAuto, "Cert-manager install mode: auto (detect and reuse existing), true (force install flow), false (skip installation)")
+	cmd.Flags().String(flagOperatorTelemetryMode, "", "Operator chart telemetry mode: off, forward, or full")
+	cmd.Flags().String(flagOperatorTelemetryNamespace, "", "Managed namespace for operator telemetry resources (defaults to the W&B CR namespace)")
+	cmd.Flags().String(flagOperatorTelemetryOTelSecretName, "", "Secret name for operator-managed telemetry connection settings")
+	cmd.Flags().String(flagOperatorTelemetryOTelProtocol, "", "OTLP protocol for operator-managed telemetry (defaults to http/protobuf)")
+	cmd.Flags().String(flagOperatorTelemetryOTelService, "", "OTEL service name for operator-managed telemetry (defaults to wandb-service)")
+	cmd.Flags().String(flagOperatorTelemetryOTelResources, "", "OTEL resource attributes for operator-managed telemetry")
+	cmd.Flags().String(flagOperatorTelemetryForwardURL, "", "Forward OTLP telemetry to this endpoint when operator telemetry mode is forward")
 
 	cmd.Flags().BoolVar(&includeCR, "include-cr", false, "Include the Wandb CR in the operator deployment")
 	return cmd
 }
 
-func performDeploy(setupCluster bool, installCertManagerMode string, includeCR bool, wait bool, clusterName string, workers int, operatorChartVersion string, wandbVersion string, operatorNamespace string) error {
+func performDeploy(setupCluster bool, installCertManagerMode string, includeCR bool, wait bool, clusterName string, workers int, operatorChartVersion string, operatorNamespace string, operatorReleaseValues map[string]interface{}) error {
 	ctx := context.Background()
 	installCertManagerMode = strings.ToLower(strings.TrimSpace(installCertManagerMode))
 
@@ -326,7 +312,7 @@ func performDeploy(setupCluster bool, installCertManagerMode string, includeCR b
 	fmt.Printf("[%d/%d] Deploying Required operators...", currentStep, totalSteps)
 	start = time.Now()
 
-	if err := operator.DeployOperator(ctx, operatorNamespace, operatorChartVersion); err != nil {
+	if err := operator.DeployOperator(ctx, operatorNamespace, operatorChartVersion, operatorReleaseValues); err != nil {
 		fmt.Println(" ✗")
 		return err
 	}
@@ -362,7 +348,7 @@ func performDeploy(setupCluster bool, installCertManagerMode string, includeCR b
 			fmt.Printf("[%d/%d] Waiting for W&B instance to be ready...", currentStep, totalSteps)
 			start = time.Now()
 
-			if err := operator.WaitForCRReady(ctx, wandbCR.Namespace, wandbCR.Name, 30*time.Minute); err != nil {
+			if err := operator.WaitForCRReady(ctx, wandbCR.GetNamespace(), wandbCR.GetName(), 30*time.Minute); err != nil {
 				fmt.Println(" ✗")
 				return err
 			}
@@ -396,7 +382,7 @@ func destroyWandbCR(ctx context.Context, name string, namespace string) error {
 }
 
 func deployWandbCR(ctx context.Context) error {
-	if err := operator.CreateNamespace(ctx, wandbCR.Namespace); err != nil {
+	if err := operator.CreateNamespace(ctx, wandbCR.GetNamespace()); err != nil {
 		return err
 	}
 
@@ -405,7 +391,7 @@ func deployWandbCR(ctx context.Context) error {
 		return err
 	}
 
-	if err := kubectl.CreateDeploymentMarker(ctx, "", wandbCR.Namespace, "wandb-cr"); err != nil {
+	if err := kubectl.CreateDeploymentMarker(ctx, "", wandbCR.GetNamespace(), "wandb-cr"); err != nil {
 		fmt.Println(" ✗")
 		return err
 	}
@@ -440,7 +426,7 @@ func performCreateCluster(ctx context.Context, clusterName string, workers int) 
 	return nil
 }
 
-func processWandbCR(crFile string, wandbVersion string, wandbName string, license string, licenseFile string, wandbNamespace string) error {
+func processWandbCR(cmd *cobra.Command, crFile string, wandbVersion string, wandbName string, license string, licenseFile string, wandbNamespace string) error {
 	if crFile != "" {
 		var err error
 		wandbCR, err = readCRFile(crFile)
@@ -448,16 +434,33 @@ func processWandbCR(crFile string, wandbVersion string, wandbName string, licens
 			fmt.Printf("failed to read CR file: %v\n", err)
 			return err
 		}
+	} else {
+		wandbCR = defaultWandbCR()
 	}
 
-	wandbCR.Name = wandbName
-
-	if wandbCR.Spec.Wandb.Version == "" && wandbVersion == "" {
-		wandbCR.Spec.Wandb.Version = defaultWandbVersion
+	if wandbCR.GetAPIVersion() == "" {
+		wandbCR.SetAPIVersion("apps.wandb.com/v2")
+	}
+	if wandbCR.GetKind() == "" {
+		wandbCR.SetKind("WeightsAndBiases")
 	}
 
-	if wandbVersion != "" {
-		wandbCR.Spec.Wandb.Version = wandbVersion
+	if crFile == "" || cmd.Flags().Changed(flagWandbName) {
+		wandbCR.SetName(wandbName)
+	}
+
+	if crFile == "" || cmd.Flags().Changed(flagWandbNamespace) {
+		wandbCR.SetNamespace(wandbNamespace)
+	}
+
+	currentVersion, _, _ := unstructured.NestedString(wandbCR.Object, "spec", "wandb", "version")
+	switch {
+	case cmd.Flags().Changed(flagWandbVersion):
+		setOrRemoveNestedString(wandbCR.Object, &wandbVersion, "spec", "wandb", "version")
+	case strings.TrimSpace(currentVersion) == "":
+		if err := unstructured.SetNestedField(wandbCR.Object, defaultWandbVersion, "spec", "wandb", "version"); err != nil {
+			return err
+		}
 	}
 
 	if license != "" && licenseFile != "" {
@@ -466,7 +469,7 @@ func processWandbCR(crFile string, wandbVersion string, wandbName string, licens
 
 	if license != "" || licenseFile != "" {
 		if license != "" {
-			wandbCR.Spec.Wandb.License = license
+			setOrRemoveNestedString(wandbCR.Object, &license, "spec", "wandb", "license")
 		}
 		if licenseFile != "" {
 			licenseData, err := os.ReadFile(licenseFile)
@@ -474,25 +477,17 @@ func processWandbCR(crFile string, wandbVersion string, wandbName string, licens
 				fmt.Printf("failed to read license file: %v\n", err)
 				return err
 			}
-			wandbCR.Spec.Wandb.License = strings.TrimSpace(string(licenseData))
+			licenseText := strings.TrimSpace(string(licenseData))
+			setOrRemoveNestedString(wandbCR.Object, &licenseText, "spec", "wandb", "license")
 		}
 	}
 
-	wandbCR.Namespace = wandbNamespace
-	return nil
-}
+	overrides, err := extractWandbCROverrides(cmd)
+	if err != nil {
+		return err
+	}
 
-func readCRFile(crPath string) (*v2.WeightsAndBiases, error) {
-	crData, err := os.ReadFile(crPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read CR file: %w", err)
-	}
-	cr := &v2.WeightsAndBiases{}
-	err = yaml.Unmarshal(crData, cr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse CR YAML: %w", err)
-	}
-	return cr, nil
+	return applyWandbCROverrides(wandbCR, overrides)
 }
 
 // ClusterCmd returns the cluster command with subcommands

--- a/cmd/wsm/deploy_v2.go
+++ b/cmd/wsm/deploy_v2.go
@@ -473,11 +473,11 @@ func processWandbCR(cmd *cobra.Command, crFile string, wandbVersion string, wand
 		wandbCR.SetKind("WeightsAndBiases")
 	}
 
-	if crFile == "" || cmd.Flags().Changed(flagWandbName) {
+	if strings.TrimSpace(wandbCR.GetName()) == "" || cmd.Flags().Changed(flagWandbName) {
 		wandbCR.SetName(wandbName)
 	}
 
-	if crFile == "" || cmd.Flags().Changed(flagWandbNamespace) {
+	if strings.TrimSpace(wandbCR.GetNamespace()) == "" || cmd.Flags().Changed(flagWandbNamespace) {
 		wandbCR.SetNamespace(wandbNamespace)
 	}
 

--- a/cmd/wsm/deploy_v2.go
+++ b/cmd/wsm/deploy_v2.go
@@ -57,12 +57,19 @@ func DeployV2Cmd() *cobra.Command {
 	cmd.PersistentFlags().String("wandb-name", "wandb", "Name of the W&B instance")
 	cmd.PersistentFlags().String("wandb-version", "", "Server manifest version (e.g., 0.76.1)")
 	cmd.PersistentFlags().String("wandb-namespace", "wandb", "Namespace for CR")
+	cmd.PersistentFlags().String(flagHostname, "", "Override spec.wandb.hostname in the generated CR")
 	cmd.PersistentFlags().Bool(flagManagedInfraTelemetryEnabled, false, "Set telemetry.enabled for all managed infrastructure components (use =false to disable)")
 	cmd.PersistentFlags().Bool(flagMySQLTelemetryEnabled, false, "Set spec.mysql managed telemetry.enabled (use =false to disable)")
 	cmd.PersistentFlags().Bool(flagRedisTelemetryEnabled, false, "Set spec.redis managed telemetry.enabled (use =false to disable)")
 	cmd.PersistentFlags().Bool(flagKafkaTelemetryEnabled, false, "Set spec.kafka managed telemetry.enabled (use =false to disable)")
 	cmd.PersistentFlags().Bool(flagObjectStoreTelemetryEnabled, false, "Set spec.objectStore managed telemetry.enabled (use =false to disable)")
 	cmd.PersistentFlags().Bool(flagClickHouseTelemetryEnabled, false, "Set spec.clickhouse managed telemetry.enabled (use =false to disable)")
+	cmd.PersistentFlags().String(flagNetworkingMode, "", "Set spec.networking.mode: none, ingress, or gateway")
+	cmd.PersistentFlags().String(flagIngressClassName, "", "Set spec.networking.ingress.ingressClassName")
+	cmd.PersistentFlags().StringToString(flagNetworkingAnnotations, map[string]string{}, "Set spec.networking.annotations (key=value,key2=value2)")
+	cmd.PersistentFlags().String(flagNetworkingTLSSecretName, "", "Set spec.networking.tls.secretName")
+	cmd.PersistentFlags().String(flagNetworkingCertManagerClusterRef, "", "Set spec.networking.tls.certManager.clusterIssuer")
+	cmd.PersistentFlags().String(flagNetworkingCertManagerIssuer, "", "Set spec.networking.tls.certManager.issuer")
 	// TODO readd this when the CR reports ready properly
 	//cmd.Flags().Bool("wait", false, "Wait for the W&B instance to be ready (status.ready == true)")
 
@@ -235,10 +242,14 @@ func operatorDeployCmd() *cobra.Command {
 func performDeploy(setupCluster bool, installCertManagerMode string, includeCR bool, wait bool, clusterName string, workers int, operatorChartVersion string, operatorNamespace string, operatorReleaseValues map[string]interface{}) error {
 	ctx := context.Background()
 	installCertManagerMode = strings.ToLower(strings.TrimSpace(installCertManagerMode))
+	installIngressController := setupCluster && includeCR && wandbCRUsesIngress(wandbCR)
 
 	// Calculate total steps based on flags
 	totalSteps := 2 // Always: ensure cert-manager, deploy operator
 	if setupCluster {
+		totalSteps++
+	}
+	if installIngressController {
 		totalSteps++
 	}
 	if includeCR {
@@ -263,6 +274,23 @@ func performDeploy(setupCluster bool, installCertManagerMode string, includeCR b
 		currentStep++
 	} else {
 		_ = clusterName
+	}
+
+	if installIngressController {
+		fmt.Printf("[%d/%d] Installing ingress-nginx...", currentStep, totalSteps)
+		start := time.Now()
+
+		if err := kind.InstallIngressNGINX(ctx); err != nil {
+			fmt.Println(" ✗")
+			return err
+		}
+		if err := kind.WaitForIngressNGINX(ctx, 5*time.Minute); err != nil {
+			fmt.Println(" ✗")
+			return err
+		}
+
+		fmt.Printf(" ✓ (%s)\n", time.Since(start).Round(time.Second))
+		currentStep++
 	}
 
 	// Step 2: Ensure cert-manager

--- a/cmd/wsm/deploy_v2_settings.go
+++ b/cmd/wsm/deploy_v2_settings.go
@@ -1,0 +1,401 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	flagManagedInfraTelemetryEnabled    = "managed-infra-telemetry-enabled"
+	flagMySQLTelemetryEnabled           = "mysql-telemetry-enabled"
+	flagRedisTelemetryEnabled           = "redis-telemetry-enabled"
+	flagKafkaTelemetryEnabled           = "kafka-telemetry-enabled"
+	flagObjectStoreTelemetryEnabled     = "object-store-telemetry-enabled"
+	flagClickHouseTelemetryEnabled      = "clickhouse-telemetry-enabled"
+	flagOperatorTelemetryForwardURL     = "operator-telemetry-forward-endpoint"
+	flagOperatorTelemetryMode           = "operator-telemetry-mode"
+	flagOperatorTelemetryNamespace      = "operator-telemetry-namespace"
+	flagOperatorTelemetryOTelProtocol   = "operator-telemetry-otel-protocol"
+	flagOperatorTelemetryOTelSecretName = "operator-telemetry-otel-secret-name"
+	flagOperatorTelemetryOTelService    = "operator-telemetry-otel-service-name"
+	flagOperatorTelemetryOTelResources  = "operator-telemetry-otel-resource-attributes"
+	flagWandbName                       = "wandb-name"
+	flagWandbNamespace                  = "wandb-namespace"
+	flagWandbVersion                    = "wandb-version"
+)
+
+type wandbCROverrides struct {
+	managedInfraTelemetryEnabled *bool
+	mysqlTelemetryEnabled        *bool
+	redisTelemetryEnabled        *bool
+	kafkaTelemetryEnabled        *bool
+	objectStoreTelemetryEnabled  *bool
+	clickHouseTelemetryEnabled   *bool
+}
+
+type operatorTelemetryOverrides struct {
+	mode               *string
+	namespace          *string
+	otelSecretName     *string
+	otelProtocol       *string
+	otelServiceName    *string
+	resourceAttributes *string
+	forwardEndpoint    *string
+}
+
+func defaultWandbCR() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps.wandb.com/v2",
+			"kind":       "WeightsAndBiases",
+			"metadata": map[string]interface{}{
+				"name": "wandb",
+			},
+			"spec": map[string]interface{}{
+				"retentionPolicy": map[string]interface{}{
+					"onDelete": "detach",
+				},
+				"wandb": map[string]interface{}{
+					"hostname": "http://localhost:8080",
+					"features": map[string]interface{}{
+						"proxy": true,
+					},
+					"internalServiceAuth": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+				"mysql": map[string]interface{}{
+					"managedMysql": map[string]interface{}{
+						"telemetry": map[string]interface{}{
+							"enabled": true,
+						},
+					},
+				},
+				"redis": map[string]interface{}{
+					"managedRedis": map[string]interface{}{
+						"telemetry": map[string]interface{}{
+							"enabled": true,
+						},
+					},
+				},
+				"kafka": map[string]interface{}{
+					"managedKafka": map[string]interface{}{
+						"telemetry": map[string]interface{}{
+							"enabled": true,
+						},
+					},
+				},
+				"objectStore": map[string]interface{}{
+					"managedObjectStore": map[string]interface{}{
+						"telemetry": map[string]interface{}{
+							"enabled": true,
+						},
+					},
+				},
+				"clickhouse": map[string]interface{}{
+					"managedClickhouse": map[string]interface{}{
+						"telemetry": map[string]interface{}{
+							"enabled": true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func readCRFile(crPath string) (*unstructured.Unstructured, error) {
+	crData, err := os.ReadFile(crPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CR file: %w", err)
+	}
+
+	var obj map[string]interface{}
+	if err := yaml.Unmarshal(crData, &obj); err != nil {
+		return nil, fmt.Errorf("failed to parse CR YAML: %w", err)
+	}
+	if len(obj) == 0 {
+		return nil, fmt.Errorf("CR YAML %q is empty", crPath)
+	}
+
+	return &unstructured.Unstructured{Object: obj}, nil
+}
+
+func extractWandbCROverrides(cmd *cobra.Command) (wandbCROverrides, error) {
+	var overrides wandbCROverrides
+	var err error
+
+	if overrides.managedInfraTelemetryEnabled, err = boolFlagIfChanged(cmd, flagManagedInfraTelemetryEnabled); err != nil {
+		return overrides, err
+	}
+	if overrides.mysqlTelemetryEnabled, err = boolFlagIfChanged(cmd, flagMySQLTelemetryEnabled); err != nil {
+		return overrides, err
+	}
+	if overrides.redisTelemetryEnabled, err = boolFlagIfChanged(cmd, flagRedisTelemetryEnabled); err != nil {
+		return overrides, err
+	}
+	if overrides.kafkaTelemetryEnabled, err = boolFlagIfChanged(cmd, flagKafkaTelemetryEnabled); err != nil {
+		return overrides, err
+	}
+	if overrides.objectStoreTelemetryEnabled, err = boolFlagIfChanged(cmd, flagObjectStoreTelemetryEnabled); err != nil {
+		return overrides, err
+	}
+	if overrides.clickHouseTelemetryEnabled, err = boolFlagIfChanged(cmd, flagClickHouseTelemetryEnabled); err != nil {
+		return overrides, err
+	}
+
+	return overrides, nil
+}
+
+func extractOperatorTelemetryOverrides(cmd *cobra.Command) (operatorTelemetryOverrides, error) {
+	var overrides operatorTelemetryOverrides
+	var err error
+
+	if overrides.mode, err = stringFlagIfChanged(cmd, flagOperatorTelemetryMode); err != nil {
+		return overrides, err
+	}
+	if overrides.namespace, err = stringFlagIfChanged(cmd, flagOperatorTelemetryNamespace); err != nil {
+		return overrides, err
+	}
+	if overrides.otelSecretName, err = stringFlagIfChanged(cmd, flagOperatorTelemetryOTelSecretName); err != nil {
+		return overrides, err
+	}
+	if overrides.otelProtocol, err = stringFlagIfChanged(cmd, flagOperatorTelemetryOTelProtocol); err != nil {
+		return overrides, err
+	}
+	if overrides.otelServiceName, err = stringFlagIfChanged(cmd, flagOperatorTelemetryOTelService); err != nil {
+		return overrides, err
+	}
+	if overrides.resourceAttributes, err = stringFlagIfChanged(cmd, flagOperatorTelemetryOTelResources); err != nil {
+		return overrides, err
+	}
+	if overrides.forwardEndpoint, err = stringFlagIfChanged(cmd, flagOperatorTelemetryForwardURL); err != nil {
+		return overrides, err
+	}
+
+	return overrides, nil
+}
+
+func applyWandbCROverrides(cr *unstructured.Unstructured, overrides wandbCROverrides) error {
+	if overrides.managedInfraTelemetryEnabled != nil {
+		for _, component := range []string{"mysql", "redis", "kafka", "objectStore", "clickhouse"} {
+			if err := setManagedInfraTelemetry(cr, component, *overrides.managedInfraTelemetryEnabled); err != nil {
+				return err
+			}
+		}
+	}
+
+	for component, enabled := range map[string]*bool{
+		"mysql":       overrides.mysqlTelemetryEnabled,
+		"redis":       overrides.redisTelemetryEnabled,
+		"kafka":       overrides.kafkaTelemetryEnabled,
+		"objectStore": overrides.objectStoreTelemetryEnabled,
+		"clickhouse":  overrides.clickHouseTelemetryEnabled,
+	} {
+		if enabled == nil {
+			continue
+		}
+		if err := setManagedInfraTelemetry(cr, component, *enabled); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func buildOperatorReleaseValues(managedNamespace string, overrides operatorTelemetryOverrides) (map[string]interface{}, error) {
+	values := map[string]interface{}{
+		"wandb": map[string]interface{}{
+			"install": false,
+		},
+	}
+
+	if !overrides.changed() {
+		return values, nil
+	}
+
+	if overrides.mode == nil {
+		return nil, fmt.Errorf("operator telemetry flags require --%s", flagOperatorTelemetryMode)
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(*overrides.mode))
+	switch mode {
+	case "off", "forward", "full":
+	default:
+		return nil, fmt.Errorf("operator telemetry mode must be one of \"off\", \"forward\", or \"full\"")
+	}
+
+	if mode == "off" {
+		if overrides.namespace != nil || overrides.otelSecretName != nil || overrides.otelProtocol != nil ||
+			overrides.otelServiceName != nil || overrides.resourceAttributes != nil || overrides.forwardEndpoint != nil {
+			return nil, fmt.Errorf("operator telemetry mode %q cannot be combined with additional operator telemetry settings", mode)
+		}
+		values["telemetry"] = map[string]interface{}{
+			"mode": "off",
+		}
+		values["victoria-metrics-operator"] = map[string]interface{}{"enabled": false}
+		values["grafana-operator"] = map[string]interface{}{"enabled": false}
+		return values, nil
+	}
+
+	if mode == "full" && overrides.forwardEndpoint != nil {
+		return nil, fmt.Errorf("--%s is only valid with --%s=forward", flagOperatorTelemetryForwardURL, flagOperatorTelemetryMode)
+	}
+
+	namespace := strings.TrimSpace(managedNamespace)
+	if overrides.namespace != nil && strings.TrimSpace(*overrides.namespace) != "" {
+		namespace = strings.TrimSpace(*overrides.namespace)
+	}
+	if namespace == "" {
+		return nil, fmt.Errorf("operator telemetry requires a managed namespace")
+	}
+
+	if overrides.otelSecretName == nil || strings.TrimSpace(*overrides.otelSecretName) == "" {
+		return nil, fmt.Errorf("--%s is required when --%s is %q or %q", flagOperatorTelemetryOTelSecretName, flagOperatorTelemetryMode, "forward", "full")
+	}
+
+	if mode == "forward" && (overrides.forwardEndpoint == nil || strings.TrimSpace(*overrides.forwardEndpoint) == "") {
+		return nil, fmt.Errorf("--%s is required when --%s=forward", flagOperatorTelemetryForwardURL, flagOperatorTelemetryMode)
+	}
+
+	telemetryValues := map[string]interface{}{
+		"mode":      mode,
+		"namespace": namespace,
+		"otel": map[string]interface{}{
+			"secretName":         strings.TrimSpace(*overrides.otelSecretName),
+			"protocol":           stringOrDefault(overrides.otelProtocol, "http/protobuf"),
+			"serviceName":        stringOrDefault(overrides.otelServiceName, "wandb-service"),
+			"resourceAttributes": stringOrDefault(overrides.resourceAttributes, ""),
+		},
+	}
+
+	if mode == "forward" {
+		telemetryValues["forwarding"] = map[string]interface{}{
+			"otlp": map[string]interface{}{
+				"endpoint": strings.TrimSpace(*overrides.forwardEndpoint),
+			},
+		}
+	}
+
+	values["telemetry"] = telemetryValues
+	values["victoria-metrics-operator"] = map[string]interface{}{"enabled": true}
+	values["grafana-operator"] = map[string]interface{}{"enabled": mode == "full"}
+
+	return values, nil
+}
+
+func (o operatorTelemetryOverrides) changed() bool {
+	return o.mode != nil || o.namespace != nil || o.otelSecretName != nil || o.otelProtocol != nil ||
+		o.otelServiceName != nil || o.resourceAttributes != nil || o.forwardEndpoint != nil
+}
+
+func setManagedInfraTelemetry(cr *unstructured.Unstructured, component string, enabled bool) error {
+	path := managedInfraTelemetryPath(cr.Object, component)
+	return unstructured.SetNestedField(cr.Object, enabled, append(path, "telemetry", "enabled")...)
+}
+
+func managedInfraTelemetryPath(obj map[string]interface{}, component string) []string {
+	switch component {
+	case "mysql":
+		if hasNestedField(obj, "spec", "mysql", "managedMysql") || !hasNestedField(obj, "spec", "mysql") {
+			return []string{"spec", "mysql", "managedMysql"}
+		}
+		return []string{"spec", "mysql"}
+	case "redis":
+		if hasNestedField(obj, "spec", "redis", "managedRedis") || !hasNestedField(obj, "spec", "redis") {
+			return []string{"spec", "redis", "managedRedis"}
+		}
+		return []string{"spec", "redis"}
+	case "kafka":
+		if hasNestedField(obj, "spec", "kafka", "managedKafka") || !hasNestedField(obj, "spec", "kafka") {
+			return []string{"spec", "kafka", "managedKafka"}
+		}
+		return []string{"spec", "kafka"}
+	case "objectStore":
+		if hasNestedField(obj, "spec", "objectStore", "managedObjectStore") || !hasNestedField(obj, "spec", "objectStore") && !hasNestedField(obj, "spec", "minio") {
+			return []string{"spec", "objectStore", "managedObjectStore"}
+		}
+		if hasNestedField(obj, "spec", "objectStore") {
+			return []string{"spec", "objectStore"}
+		}
+		return []string{"spec", "minio"}
+	case "clickhouse":
+		if hasNestedField(obj, "spec", "clickhouse", "managedClickhouse") || !hasNestedField(obj, "spec", "clickhouse") {
+			return []string{"spec", "clickhouse", "managedClickhouse"}
+		}
+		return []string{"spec", "clickhouse"}
+	default:
+		return []string{"spec", component}
+	}
+}
+
+func stringFlagIfChanged(cmd *cobra.Command, name string) (*string, error) {
+	if !cmd.Flags().Changed(name) {
+		return nil, nil
+	}
+	value, err := cmd.Flags().GetString(name)
+	if err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func boolFlagIfChanged(cmd *cobra.Command, name string) (*bool, error) {
+	if !cmd.Flags().Changed(name) {
+		return nil, nil
+	}
+	value, err := cmd.Flags().GetBool(name)
+	if err != nil {
+		return nil, err
+	}
+	return &value, nil
+}
+
+func setOrRemoveNestedString(obj map[string]interface{}, value *string, fields ...string) {
+	if value == nil {
+		return
+	}
+	if strings.TrimSpace(*value) == "" {
+		removeNestedFieldAndEmptyParents(obj, fields...)
+		return
+	}
+	_ = unstructured.SetNestedField(obj, strings.TrimSpace(*value), fields...)
+}
+
+func removeNestedFieldAndEmptyParents(obj map[string]interface{}, fields ...string) {
+	if len(fields) == 0 {
+		return
+	}
+	unstructured.RemoveNestedField(obj, fields...)
+	for depth := len(fields) - 1; depth > 0; depth-- {
+		removeEmptyMap(obj, fields[:depth]...)
+	}
+}
+
+func removeEmptyMap(obj map[string]interface{}, fields ...string) {
+	if len(fields) == 0 {
+		return
+	}
+	value, found, err := unstructured.NestedMap(obj, fields...)
+	if err != nil || !found || len(value) > 0 {
+		return
+	}
+	unstructured.RemoveNestedField(obj, fields...)
+}
+
+func hasNestedField(obj map[string]interface{}, fields ...string) bool {
+	_, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
+	return err == nil && found
+}
+
+func stringOrDefault(value *string, fallback string) string {
+	if value == nil {
+		return fallback
+	}
+	return strings.TrimSpace(*value)
+}

--- a/cmd/wsm/deploy_v2_settings.go
+++ b/cmd/wsm/deploy_v2_settings.go
@@ -540,5 +540,9 @@ func stringOrDefault(value *string, fallback string) string {
 	if value == nil {
 		return fallback
 	}
-	return strings.TrimSpace(*value)
+	trimmed := strings.TrimSpace(*value)
+	if trimmed == "" {
+		return fallback
+	}
+	return trimmed
 }

--- a/cmd/wsm/deploy_v2_settings.go
+++ b/cmd/wsm/deploy_v2_settings.go
@@ -11,12 +11,22 @@ import (
 )
 
 const (
+	flagCRFile                          = "cr-file"
+	flagHostname                        = "hostname"
+	flagIngressClassName                = "ingress-class-name"
+	flagLicense                         = "license"
+	flagLicenseFile                     = "license-file"
 	flagManagedInfraTelemetryEnabled    = "managed-infra-telemetry-enabled"
 	flagMySQLTelemetryEnabled           = "mysql-telemetry-enabled"
 	flagRedisTelemetryEnabled           = "redis-telemetry-enabled"
 	flagKafkaTelemetryEnabled           = "kafka-telemetry-enabled"
 	flagObjectStoreTelemetryEnabled     = "object-store-telemetry-enabled"
 	flagClickHouseTelemetryEnabled      = "clickhouse-telemetry-enabled"
+	flagNetworkingAnnotations           = "networking-annotations"
+	flagNetworkingMode                  = "networking-mode"
+	flagNetworkingTLSSecretName         = "networking-tls-secret-name"
+	flagNetworkingCertManagerIssuer     = "networking-cert-manager-issuer"
+	flagNetworkingCertManagerClusterRef = "networking-cert-manager-cluster-issuer"
 	flagOperatorTelemetryForwardURL     = "operator-telemetry-forward-endpoint"
 	flagOperatorTelemetryMode           = "operator-telemetry-mode"
 	flagOperatorTelemetryNamespace      = "operator-telemetry-namespace"
@@ -30,12 +40,19 @@ const (
 )
 
 type wandbCROverrides struct {
-	managedInfraTelemetryEnabled *bool
-	mysqlTelemetryEnabled        *bool
-	redisTelemetryEnabled        *bool
-	kafkaTelemetryEnabled        *bool
-	objectStoreTelemetryEnabled  *bool
-	clickHouseTelemetryEnabled   *bool
+	hostname                        *string
+	networkingMode                  *string
+	ingressClassName                *string
+	networkingAnnotations           map[string]string
+	networkingTLSSecretName         *string
+	networkingCertManagerIssuer     *string
+	networkingCertManagerClusterRef *string
+	managedInfraTelemetryEnabled    *bool
+	mysqlTelemetryEnabled           *bool
+	redisTelemetryEnabled           *bool
+	kafkaTelemetryEnabled           *bool
+	objectStoreTelemetryEnabled     *bool
+	clickHouseTelemetryEnabled      *bool
 }
 
 type operatorTelemetryOverrides struct {
@@ -130,6 +147,24 @@ func extractWandbCROverrides(cmd *cobra.Command) (wandbCROverrides, error) {
 	var overrides wandbCROverrides
 	var err error
 
+	if overrides.hostname, err = stringFlagIfChanged(cmd, flagHostname); err != nil {
+		return overrides, err
+	}
+	if overrides.networkingMode, err = stringFlagIfChanged(cmd, flagNetworkingMode); err != nil {
+		return overrides, err
+	}
+	if overrides.ingressClassName, err = stringFlagIfChanged(cmd, flagIngressClassName); err != nil {
+		return overrides, err
+	}
+	if overrides.networkingTLSSecretName, err = stringFlagIfChanged(cmd, flagNetworkingTLSSecretName); err != nil {
+		return overrides, err
+	}
+	if overrides.networkingCertManagerIssuer, err = stringFlagIfChanged(cmd, flagNetworkingCertManagerIssuer); err != nil {
+		return overrides, err
+	}
+	if overrides.networkingCertManagerClusterRef, err = stringFlagIfChanged(cmd, flagNetworkingCertManagerClusterRef); err != nil {
+		return overrides, err
+	}
 	if overrides.managedInfraTelemetryEnabled, err = boolFlagIfChanged(cmd, flagManagedInfraTelemetryEnabled); err != nil {
 		return overrides, err
 	}
@@ -147,6 +182,13 @@ func extractWandbCROverrides(cmd *cobra.Command) (wandbCROverrides, error) {
 	}
 	if overrides.clickHouseTelemetryEnabled, err = boolFlagIfChanged(cmd, flagClickHouseTelemetryEnabled); err != nil {
 		return overrides, err
+	}
+	if cmd.Flags().Changed(flagNetworkingAnnotations) {
+		annotations, err := cmd.Flags().GetStringToString(flagNetworkingAnnotations)
+		if err != nil {
+			return overrides, err
+		}
+		overrides.networkingAnnotations = annotations
 	}
 
 	return overrides, nil
@@ -182,6 +224,63 @@ func extractOperatorTelemetryOverrides(cmd *cobra.Command) (operatorTelemetryOve
 }
 
 func applyWandbCROverrides(cr *unstructured.Unstructured, overrides wandbCROverrides) error {
+	if overrides.hostname != nil {
+		setOrRemoveNestedString(cr.Object, overrides.hostname, "spec", "wandb", "hostname")
+	}
+
+	mode := overrides.networkingMode
+	if mode == nil && overrides.ingressClassName != nil {
+		defaultMode := "ingress"
+		mode = &defaultMode
+	}
+
+	normalizedMode, err := normalizeNetworkingMode(mode)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case normalizedMode != nil && *normalizedMode == "":
+		unstructured.RemoveNestedField(cr.Object, "spec", "networking", "mode")
+	case normalizedMode != nil:
+		if err := unstructured.SetNestedField(cr.Object, *normalizedMode, "spec", "networking", "mode"); err != nil {
+			return err
+		}
+	}
+
+	if normalizedMode != nil {
+		switch *normalizedMode {
+		case "ingress":
+			removeNestedFieldAndEmptyParents(cr.Object, "spec", "networking", "gatewayAPI")
+		case "gateway":
+			removeNestedFieldAndEmptyParents(cr.Object, "spec", "networking", "ingress")
+		}
+	}
+
+	if overrides.ingressClassName != nil {
+		if normalizedMode != nil && *normalizedMode == "gateway" {
+			return fmt.Errorf("%s requires --%s=ingress", flagIngressClassName, flagNetworkingMode)
+		}
+		setOrRemoveNestedString(cr.Object, overrides.ingressClassName, "spec", "networking", "ingress", "ingressClassName")
+	}
+
+	if overrides.networkingAnnotations != nil {
+		if len(overrides.networkingAnnotations) == 0 {
+			removeNestedFieldAndEmptyParents(cr.Object, "spec", "networking", "annotations")
+		} else if err := unstructured.SetNestedStringMap(cr.Object, sanitizeStringMap(overrides.networkingAnnotations), "spec", "networking", "annotations"); err != nil {
+			return err
+		}
+	}
+
+	setOrRemoveNestedString(cr.Object, overrides.networkingTLSSecretName, "spec", "networking", "tls", "secretName")
+	setOrRemoveNestedString(cr.Object, overrides.networkingCertManagerClusterRef, "spec", "networking", "tls", "certManager", "clusterIssuer")
+	setOrRemoveNestedString(cr.Object, overrides.networkingCertManagerIssuer, "spec", "networking", "tls", "certManager", "issuer")
+
+	removeEmptyMap(cr.Object, "spec", "networking", "tls", "certManager")
+	removeEmptyMap(cr.Object, "spec", "networking", "tls")
+	removeEmptyMap(cr.Object, "spec", "networking", "ingress")
+	removeEmptyMap(cr.Object, "spec", "networking")
+
 	if overrides.managedInfraTelemetryEnabled != nil {
 		for _, component := range []string{"mysql", "redis", "kafka", "objectStore", "clickhouse"} {
 			if err := setManagedInfraTelemetry(cr, component, *overrides.managedInfraTelemetryEnabled); err != nil {
@@ -294,6 +393,25 @@ func (o operatorTelemetryOverrides) changed() bool {
 		o.otelServiceName != nil || o.resourceAttributes != nil || o.forwardEndpoint != nil
 }
 
+func normalizeNetworkingMode(mode *string) (*string, error) {
+	if mode == nil {
+		return nil, nil
+	}
+
+	normalized := strings.ToLower(strings.TrimSpace(*mode))
+	switch normalized {
+	case "", "none":
+		normalized = ""
+	case "ingress":
+	case "gateway", "gatewayapi":
+		normalized = "gateway"
+	default:
+		return nil, fmt.Errorf("networking mode must be one of \"none\", \"ingress\", or \"gateway\"")
+	}
+
+	return &normalized, nil
+}
+
 func setManagedInfraTelemetry(cr *unstructured.Unstructured, component string, enabled bool) error {
 	path := managedInfraTelemetryPath(cr.Object, component)
 	return unstructured.SetNestedField(cr.Object, enabled, append(path, "telemetry", "enabled")...)
@@ -391,6 +509,23 @@ func removeEmptyMap(obj map[string]interface{}, fields ...string) {
 func hasNestedField(obj map[string]interface{}, fields ...string) bool {
 	_, found, err := unstructured.NestedFieldNoCopy(obj, fields...)
 	return err == nil && found
+}
+
+func sanitizeStringMap(values map[string]string) map[string]string {
+	out := make(map[string]string, len(values))
+	for key, value := range values {
+		trimmedKey := strings.TrimSpace(key)
+		if trimmedKey == "" {
+			continue
+		}
+		out[trimmedKey] = strings.TrimSpace(value)
+	}
+	return out
+}
+
+func wandbCRUsesIngress(cr *unstructured.Unstructured) bool {
+	mode, found, err := unstructured.NestedString(cr.Object, "spec", "networking", "mode")
+	return err == nil && found && strings.EqualFold(mode, "ingress")
 }
 
 func stringOrDefault(value *string, fallback string) string {

--- a/cmd/wsm/deploy_v2_settings.go
+++ b/cmd/wsm/deploy_v2_settings.go
@@ -241,7 +241,10 @@ func applyWandbCROverrides(cr *unstructured.Unstructured, overrides wandbCROverr
 
 	switch {
 	case normalizedMode != nil && *normalizedMode == "":
-		unstructured.RemoveNestedField(cr.Object, "spec", "networking", "mode")
+		if overrides.hasAdditionalNetworkingConfig() {
+			return fmt.Errorf("--%s=none cannot be combined with other networking settings", flagNetworkingMode)
+		}
+		removeNestedFieldAndEmptyParents(cr.Object, "spec", "networking")
 	case normalizedMode != nil:
 		if err := unstructured.SetNestedField(cr.Object, *normalizedMode, "spec", "networking", "mode"); err != nil {
 			return err
@@ -391,6 +394,11 @@ func buildOperatorReleaseValues(managedNamespace string, overrides operatorTelem
 func (o operatorTelemetryOverrides) changed() bool {
 	return o.mode != nil || o.namespace != nil || o.otelSecretName != nil || o.otelProtocol != nil ||
 		o.otelServiceName != nil || o.resourceAttributes != nil || o.forwardEndpoint != nil
+}
+
+func (o wandbCROverrides) hasAdditionalNetworkingConfig() bool {
+	return o.ingressClassName != nil || o.networkingAnnotations != nil || o.networkingTLSSecretName != nil ||
+		o.networkingCertManagerIssuer != nil || o.networkingCertManagerClusterRef != nil
 }
 
 func normalizeNetworkingMode(mode *string) (*string, error) {

--- a/cmd/wsm/deploy_v2_settings_test.go
+++ b/cmd/wsm/deploy_v2_settings_test.go
@@ -9,17 +9,46 @@ import (
 func TestApplyWandbCROverridesCurrentSchema(t *testing.T) {
 	cr := defaultWandbCR()
 
+	host := "https://wandb.example.com"
+	mode := "ingress"
+	ingressClass := "nginx"
+	tlsSecret := "wandb-tls"
+	clusterIssuer := "letsencrypt"
 	disableTelemetry := false
 	enableMySQLTelemetry := true
 
 	err := applyWandbCROverrides(cr, wandbCROverrides{
-		managedInfraTelemetryEnabled: &disableTelemetry,
-		mysqlTelemetryEnabled:        &enableMySQLTelemetry,
+		hostname:                        &host,
+		networkingMode:                  &mode,
+		ingressClassName:                &ingressClass,
+		networkingAnnotations:           map[string]string{" nginx.ingress.kubernetes.io/proxy-body-size ": " 0 "},
+		networkingTLSSecretName:         &tlsSecret,
+		networkingCertManagerClusterRef: &clusterIssuer,
+		managedInfraTelemetryEnabled:    &disableTelemetry,
+		mysqlTelemetryEnabled:           &enableMySQLTelemetry,
 	})
 	if err != nil {
 		t.Fatalf("applyWandbCROverrides returned error: %v", err)
 	}
 
+	if got, _, _ := unstructured.NestedString(cr.Object, "spec", "wandb", "hostname"); got != host {
+		t.Fatalf("expected hostname %q, got %q", host, got)
+	}
+	if got, _, _ := unstructured.NestedString(cr.Object, "spec", "networking", "mode"); got != "ingress" {
+		t.Fatalf("expected networking mode ingress, got %q", got)
+	}
+	if got, _, _ := unstructured.NestedString(cr.Object, "spec", "networking", "ingress", "ingressClassName"); got != ingressClass {
+		t.Fatalf("expected ingressClassName %q, got %q", ingressClass, got)
+	}
+	if got, _, _ := unstructured.NestedString(cr.Object, "spec", "networking", "tls", "secretName"); got != tlsSecret {
+		t.Fatalf("expected tls secret %q, got %q", tlsSecret, got)
+	}
+	if got, _, _ := unstructured.NestedString(cr.Object, "spec", "networking", "tls", "certManager", "clusterIssuer"); got != clusterIssuer {
+		t.Fatalf("expected cluster issuer %q, got %q", clusterIssuer, got)
+	}
+	if got, _, _ := unstructured.NestedStringMap(cr.Object, "spec", "networking", "annotations"); got["nginx.ingress.kubernetes.io/proxy-body-size"] != "0" {
+		t.Fatalf("expected trimmed annotation value, got %#v", got)
+	}
 	if got, _, _ := unstructured.NestedBool(cr.Object, "spec", "mysql", "managedMysql", "telemetry", "enabled"); !got {
 		t.Fatalf("expected mysql telemetry to remain enabled")
 	}
@@ -62,6 +91,20 @@ func TestApplyWandbCROverridesFallsBackToOldTelemetryPaths(t *testing.T) {
 	}
 	if _, found, _ := unstructured.NestedFieldNoCopy(cr.Object, "spec", "mysql", "managedMysql"); found {
 		t.Fatalf("did not expect managedMysql path to be created for old-style CR")
+	}
+}
+
+func TestApplyWandbCROverridesRejectsIngressClassWithGatewayMode(t *testing.T) {
+	cr := defaultWandbCR()
+	mode := "gateway"
+	ingressClass := "nginx"
+
+	err := applyWandbCROverrides(cr, wandbCROverrides{
+		networkingMode:   &mode,
+		ingressClassName: &ingressClass,
+	})
+	if err == nil {
+		t.Fatalf("expected error when ingress class is combined with gateway mode")
 	}
 }
 

--- a/cmd/wsm/deploy_v2_settings_test.go
+++ b/cmd/wsm/deploy_v2_settings_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestApplyWandbCROverridesCurrentSchema(t *testing.T) {
+	cr := defaultWandbCR()
+
+	disableTelemetry := false
+	enableMySQLTelemetry := true
+
+	err := applyWandbCROverrides(cr, wandbCROverrides{
+		managedInfraTelemetryEnabled: &disableTelemetry,
+		mysqlTelemetryEnabled:        &enableMySQLTelemetry,
+	})
+	if err != nil {
+		t.Fatalf("applyWandbCROverrides returned error: %v", err)
+	}
+
+	if got, _, _ := unstructured.NestedBool(cr.Object, "spec", "mysql", "managedMysql", "telemetry", "enabled"); !got {
+		t.Fatalf("expected mysql telemetry to remain enabled")
+	}
+	if got, _, _ := unstructured.NestedBool(cr.Object, "spec", "redis", "managedRedis", "telemetry", "enabled"); got {
+		t.Fatalf("expected redis telemetry to be disabled")
+	}
+	if got, _, _ := unstructured.NestedBool(cr.Object, "spec", "objectStore", "managedObjectStore", "telemetry", "enabled"); got {
+		t.Fatalf("expected objectStore telemetry to be disabled")
+	}
+}
+
+func TestApplyWandbCROverridesFallsBackToOldTelemetryPaths(t *testing.T) {
+	cr := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps.wandb.com/v2",
+			"kind":       "WeightsAndBiases",
+			"spec": map[string]interface{}{
+				"mysql":      map[string]interface{}{},
+				"redis":      map[string]interface{}{},
+				"kafka":      map[string]interface{}{},
+				"minio":      map[string]interface{}{},
+				"clickhouse": map[string]interface{}{},
+			},
+		},
+	}
+
+	disableTelemetry := false
+	err := applyWandbCROverrides(cr, wandbCROverrides{
+		managedInfraTelemetryEnabled: &disableTelemetry,
+	})
+	if err != nil {
+		t.Fatalf("applyWandbCROverrides returned error: %v", err)
+	}
+
+	if got, _, _ := unstructured.NestedBool(cr.Object, "spec", "mysql", "telemetry", "enabled"); got {
+		t.Fatalf("expected old mysql telemetry path to be disabled")
+	}
+	if got, _, _ := unstructured.NestedBool(cr.Object, "spec", "minio", "telemetry", "enabled"); got {
+		t.Fatalf("expected old minio telemetry path to be disabled")
+	}
+	if _, found, _ := unstructured.NestedFieldNoCopy(cr.Object, "spec", "mysql", "managedMysql"); found {
+		t.Fatalf("did not expect managedMysql path to be created for old-style CR")
+	}
+}
+
+func TestBuildOperatorReleaseValuesForwardMode(t *testing.T) {
+	mode := "forward"
+	secretName := "wandb-otel-connection"
+	forwardEndpoint := "https://otel.example.com"
+
+	values, err := buildOperatorReleaseValues("wandb", operatorTelemetryOverrides{
+		mode:            &mode,
+		otelSecretName:  &secretName,
+		forwardEndpoint: &forwardEndpoint,
+	})
+	if err != nil {
+		t.Fatalf("buildOperatorReleaseValues returned error: %v", err)
+	}
+
+	if got, _, _ := unstructured.NestedString(values, "telemetry", "mode"); got != "forward" {
+		t.Fatalf("expected telemetry.mode=forward, got %q", got)
+	}
+	if got, _, _ := unstructured.NestedString(values, "telemetry", "namespace"); got != "wandb" {
+		t.Fatalf("expected telemetry namespace wandb, got %q", got)
+	}
+	if got, _, _ := unstructured.NestedString(values, "telemetry", "otel", "secretName"); got != secretName {
+		t.Fatalf("expected telemetry.otel.secretName %q, got %q", secretName, got)
+	}
+	if got, _, _ := unstructured.NestedString(values, "telemetry", "forwarding", "otlp", "endpoint"); got != forwardEndpoint {
+		t.Fatalf("expected telemetry forwarding endpoint %q, got %q", forwardEndpoint, got)
+	}
+	if got, _, _ := unstructured.NestedBool(values, "victoria-metrics-operator", "enabled"); !got {
+		t.Fatalf("expected victoria-metrics-operator to be enabled")
+	}
+	if got, _, _ := unstructured.NestedBool(values, "grafana-operator", "enabled"); got {
+		t.Fatalf("expected grafana-operator to remain disabled in forward mode")
+	}
+}
+
+func TestBuildOperatorReleaseValuesRequiresModeForOtherFlags(t *testing.T) {
+	secretName := "wandb-otel-connection"
+
+	_, err := buildOperatorReleaseValues("wandb", operatorTelemetryOverrides{
+		otelSecretName: &secretName,
+	})
+	if err == nil {
+		t.Fatalf("expected error when operator telemetry flags are set without a mode")
+	}
+}

--- a/cmd/wsm/deploy_v2_settings_test.go
+++ b/cmd/wsm/deploy_v2_settings_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -215,5 +218,40 @@ func TestBuildOperatorReleaseValuesTreatsEmptyOTelStringsAsUnset(t *testing.T) {
 	}
 	if got, _, _ := unstructured.NestedString(values, "telemetry", "otel", "serviceName"); got != "wandb-service" {
 		t.Fatalf("expected telemetry.otel.serviceName to fall back to default, got %q", got)
+	}
+}
+
+func TestProcessWandbCRFillsMissingMetadataFromDefaults(t *testing.T) {
+	previousCR := wandbCR
+	t.Cleanup(func() {
+		wandbCR = previousCR
+	})
+
+	crPath := filepath.Join(t.TempDir(), "wandb.yaml")
+	crYAML := []byte(`
+apiVersion: apps.wandb.com/v2
+kind: WeightsAndBiases
+spec:
+  wandb:
+    version: 0.79.0
+`)
+	if err := os.WriteFile(crPath, crYAML, 0o644); err != nil {
+		t.Fatalf("failed to write CR fixture: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String(flagWandbName, "wandb", "")
+	cmd.Flags().String(flagWandbNamespace, "wandb", "")
+	cmd.Flags().String(flagWandbVersion, "", "")
+
+	if err := processWandbCR(cmd, crPath, "", "default-name", "", "", "default-namespace"); err != nil {
+		t.Fatalf("processWandbCR returned error: %v", err)
+	}
+
+	if got := wandbCR.GetName(); got != "default-name" {
+		t.Fatalf("expected metadata.name to be defaulted, got %q", got)
+	}
+	if got := wandbCR.GetNamespace(); got != "default-namespace" {
+		t.Fatalf("expected metadata.namespace to be defaulted, got %q", got)
 	}
 }

--- a/cmd/wsm/deploy_v2_settings_test.go
+++ b/cmd/wsm/deploy_v2_settings_test.go
@@ -194,3 +194,26 @@ func TestBuildOperatorReleaseValuesRequiresModeForOtherFlags(t *testing.T) {
 		t.Fatalf("expected error when operator telemetry flags are set without a mode")
 	}
 }
+
+func TestBuildOperatorReleaseValuesTreatsEmptyOTelStringsAsUnset(t *testing.T) {
+	mode := "full"
+	secretName := "wandb-otel-connection"
+	empty := "   "
+
+	values, err := buildOperatorReleaseValues("wandb", operatorTelemetryOverrides{
+		mode:            &mode,
+		otelSecretName:  &secretName,
+		otelProtocol:    &empty,
+		otelServiceName: &empty,
+	})
+	if err != nil {
+		t.Fatalf("buildOperatorReleaseValues returned error: %v", err)
+	}
+
+	if got, _, _ := unstructured.NestedString(values, "telemetry", "otel", "protocol"); got != "http/protobuf" {
+		t.Fatalf("expected telemetry.otel.protocol to fall back to default, got %q", got)
+	}
+	if got, _, _ := unstructured.NestedString(values, "telemetry", "otel", "serviceName"); got != "wandb-service" {
+		t.Fatalf("expected telemetry.otel.serviceName to fall back to default, got %q", got)
+	}
+}

--- a/cmd/wsm/deploy_v2_settings_test.go
+++ b/cmd/wsm/deploy_v2_settings_test.go
@@ -108,6 +108,48 @@ func TestApplyWandbCROverridesRejectsIngressClassWithGatewayMode(t *testing.T) {
 	}
 }
 
+func TestApplyWandbCROverridesNetworkingModeNoneRemovesEntireNetworkingTree(t *testing.T) {
+	cr := defaultWandbCR()
+	if err := unstructured.SetNestedField(cr.Object, "gateway", "spec", "networking", "mode"); err != nil {
+		t.Fatalf("failed to seed networking mode: %v", err)
+	}
+	if err := unstructured.SetNestedField(cr.Object, "existing", "spec", "networking", "ingress", "ingressClassName"); err != nil {
+		t.Fatalf("failed to seed ingress class: %v", err)
+	}
+	if err := unstructured.SetNestedField(cr.Object, "listener", "spec", "networking", "gatewayAPI", "listenerName"); err != nil {
+		t.Fatalf("failed to seed gateway listener: %v", err)
+	}
+	if err := unstructured.SetNestedField(cr.Object, "tls-secret", "spec", "networking", "tls", "secretName"); err != nil {
+		t.Fatalf("failed to seed tls secret: %v", err)
+	}
+	if err := unstructured.SetNestedStringMap(cr.Object, map[string]string{"foo": "bar"}, "spec", "networking", "annotations"); err != nil {
+		t.Fatalf("failed to seed annotations: %v", err)
+	}
+
+	mode := "none"
+	if err := applyWandbCROverrides(cr, wandbCROverrides{networkingMode: &mode}); err != nil {
+		t.Fatalf("applyWandbCROverrides returned error: %v", err)
+	}
+
+	if _, found, _ := unstructured.NestedFieldNoCopy(cr.Object, "spec", "networking"); found {
+		t.Fatalf("expected spec.networking to be removed entirely")
+	}
+}
+
+func TestApplyWandbCROverridesRejectsNetworkingModeNoneWithOtherNetworkingFlags(t *testing.T) {
+	cr := defaultWandbCR()
+	mode := "none"
+	ingressClass := "nginx"
+
+	err := applyWandbCROverrides(cr, wandbCROverrides{
+		networkingMode:   &mode,
+		ingressClassName: &ingressClass,
+	})
+	if err == nil {
+		t.Fatalf("expected error when networking mode none is combined with other networking settings")
+	}
+}
+
 func TestBuildOperatorReleaseValuesForwardMode(t *testing.T) {
 	mode := "forward"
 	secretName := "wandb-otel-connection"

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/docker/go-connections/tlsconfig"
-	v2 "github.com/wandb/operator/api/v2"
 	"github.com/wandb/wsm/pkg/kubectl"
 	"helm.sh/helm/v4/pkg/action"
 	"helm.sh/helm/v4/pkg/chart/loader"
@@ -21,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -156,7 +154,7 @@ func DeleteCertManager(ctx context.Context) error {
 }
 
 // DeployOperator deploys the W&B operator chart version specified.  The chart is called operator and is available in oci://us-docker.pkg.dev/wandb-production/public/wandb/charts
-func DeployOperator(ctx context.Context, namespace string, version string) error {
+func DeployOperator(ctx context.Context, namespace string, version string, releaseValues map[string]interface{}) error {
 	const repositoryURL = "oci://us-docker.pkg.dev/wandb-production/public/wandb/charts"
 	const chartName = "operator"
 	const chartRef = repositoryURL + "/" + chartName
@@ -185,11 +183,16 @@ func DeployOperator(ctx context.Context, namespace string, version string) error
 		return fmt.Errorf("failed to check if release exists: %w", err)
 	}
 
-	releaseValues := map[string]interface{}{
-		"wandb": map[string]interface{}{
-			"install": false,
-		},
+	if releaseValues == nil {
+		releaseValues = map[string]interface{}{}
 	}
+
+	wandbValues, ok := releaseValues["wandb"].(map[string]interface{})
+	if !ok || wandbValues == nil {
+		wandbValues = map[string]interface{}{}
+	}
+	wandbValues["install"] = false
+	releaseValues["wandb"] = wandbValues
 
 	if releaseExists {
 		// Create upgrade action
@@ -440,7 +443,7 @@ func newRegistryClient(settings *cli.EnvSettings, certFile, keyFile, caFile stri
 }
 
 // ApplyCR applies a WeightsAndBiases CR to the cluster (idempotent)
-func ApplyCR(ctx context.Context, wandbCR *v2.WeightsAndBiases) error {
+func ApplyCR(ctx context.Context, wandbCR *unstructured.Unstructured) error {
 	_, dyn, err := kubectl.GetDynamicClientset()
 	if err != nil {
 		return err
@@ -464,11 +467,7 @@ func ApplyCR(ctx context.Context, wandbCR *v2.WeightsAndBiases) error {
 		}
 	}
 
-	data, err := runtime.DefaultUnstructuredConverter.ToUnstructured(wandbCR)
-	if err != nil {
-		return fmt.Errorf("failed to convert to unstructured: %w", err)
-	}
-	obj := &unstructured.Unstructured{Object: data}
+	obj := wandbCR.DeepCopy()
 
 	// Ensure GVK is set on the unstructured object
 	obj.SetGroupVersionKind(gvk)
@@ -478,9 +477,9 @@ func ApplyCR(ctx context.Context, wandbCR *v2.WeightsAndBiases) error {
 		return fmt.Errorf("failed to marshal CR: %w", err)
 	}
 
-	dr := dyn.Resource(mapping.Resource).Namespace(wandbCR.Namespace)
+	dr := dyn.Resource(mapping.Resource).Namespace(wandbCR.GetNamespace())
 
-	if _, err := dr.Patch(ctx, wandbCR.Name, types.ApplyPatchType, raw, metav1.PatchOptions{
+	if _, err := dr.Patch(ctx, wandbCR.GetName(), types.ApplyPatchType, raw, metav1.PatchOptions{
 		FieldManager: "wsm",
 	}); err != nil {
 		return fmt.Errorf("failed to apply CR: %w", err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added telemetry configuration flags for operator deployment: `--operator-telemetry-mode`, `--operator-telemetry-namespace`, `--operator-telemetry-otel-secret-name`, and `--operator-telemetry-forward-endpoint`.
  * Added `--hostname` flag to override deployment hostname.
  * Added managed infrastructure telemetry enablement flags for deployment components.
  * Added networking configuration flags including ingress class, annotations, and TLS settings.
  * Automatic `ingress-nginx` installation when deploying with ingress networking.

* **Documentation**
  * Updated CLI flag documentation for `wsm deploy-v2` commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->