### PR TITLE
Feat(upgrade wsm)

### DIFF
--- a/cmd/wsm/deploy_v2.go
+++ b/cmd/wsm/deploy_v2.go
@@ -787,7 +787,7 @@ func createCAIssuer(ctx context.Context, wandbName string, namespace string) err
 			IsCA:       true,
 			CommonName: "wandb-ca",
 			Duration:   &metav1.Duration{Duration: 8760 * 24 * time.Hour},
-			IssuerRef: certmanagermetav1.ObjectReference{
+			IssuerRef: certmanagermetav1.IssuerReference{
 				Name:  selfSignedIssuerName,
 				Kind:  "Issuer",
 				Group: "cert-manager.io",

--- a/cmd/wsm/upgrade.go
+++ b/cmd/wsm/upgrade.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/spf13/cobra"
+	"github.com/wandb/wsm/pkg/kubectl"
+	"github.com/wandb/wsm/pkg/operator"
+)
+
+func init() {
+	rootCmd.AddCommand(UpgradeCmd())
+}
+
+func UpgradeCmd() *cobra.Command {
+	var (
+		kubeContext    string
+		wandbName      string
+		wandbNamespace string
+		wandbVersion   string
+		wait           bool
+		timeout        time.Duration
+		force          bool
+		dryRun         bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade an existing wsm-managed W&B instance to a new version",
+		Long:  `Patch spec.wandb.version on a WeightsAndBiases CR that wsm previously deployed.`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if kubeContext == "" {
+				return errors.New("--context is required")
+			}
+			if wandbVersion == "" {
+				return errors.New("--wandb-version is required")
+			}
+			kubectl.SetContext(kubeContext)
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			hasMarker, err := kubectl.HasDeploymentMarker(ctx, wandbNamespace, "wandb-cr")
+			if err != nil {
+				return err
+			}
+			if !hasMarker {
+				return fmt.Errorf("no wsm deployment marker found in namespace %q — refusing to upgrade an install wsm did not deploy", wandbNamespace)
+			}
+
+			currentCR, err := operator.GetCR(ctx, wandbName, wandbNamespace)
+			currentCR.ManagedFields = nil
+			currentCR.ResourceVersion = ""
+			if err != nil {
+				return fmt.Errorf("failed to read current CR: %w", err)
+			}
+
+			currentVersion := currentCR.Spec.Wandb.Version
+			if currentVersion == wandbVersion {
+				fmt.Printf("✓ %s/%s is already at version %s, nothing to do.\n", wandbNamespace, wandbName, wandbVersion)
+				return nil
+			}
+
+			if !force {
+				down, cmpErr := isDowngrade(currentVersion, wandbVersion)
+				if cmpErr != nil {
+					return fmt.Errorf("%w (pass --force to proceed anyway)", cmpErr)
+				}
+				if down {
+					return fmt.Errorf("refusing to downgrade %s → %s (pass --force to override)", currentVersion, wandbVersion)
+				}
+			}
+
+			fmt.Printf("Upgrade plan for %s/%s:\n", wandbNamespace, wandbName)
+			fmt.Printf("  spec.wandb.version: %s → %s\n", currentVersion, wandbVersion)
+
+			if dryRun {
+				fmt.Println("(dry-run) no changes applied.")
+				return nil
+			} else {
+				fmt.Print("Proceed? [y/N]: ")
+				answer, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+				answer = strings.ToLower(strings.TrimSpace(answer))
+				if answer != "y" {
+					fmt.Println("aborted.")
+					return nil
+				}
+			}
+
+			currentCR.Spec.Wandb.Version = wandbVersion
+
+			start := time.Now()
+			fmt.Print("→ Applying upgrade...")
+			if err := operator.ApplyCR(ctx, currentCR); err != nil {
+				return fmt.Errorf("failed to apply upgrade: %w", err)
+			}
+			fmt.Printf(" (%s)\n", time.Since(start).Round(time.Second))
+
+			if wait {
+				fmt.Printf("→ Waiting for %s/%s to be ready (timeout %s)...\n", wandbNamespace, wandbName, timeout)
+				if err := operator.WaitForCRReady(ctx, wandbNamespace, wandbName, timeout); err != nil {
+					return fmt.Errorf("instance did not become ready: %w", err)
+				}
+				fmt.Println("Upgrade complete.")
+			} else {
+				fmt.Printf("Upgrade applied. Check status with: kubectl get wandb -n %s %s\n", wandbNamespace, wandbName)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&kubeContext, "context", "", "name of the kubeconfig context to use (required)")
+	cmd.Flags().StringVar(&wandbName, "wandb-name", "wandb", "Name of the W&B instance")
+	cmd.Flags().StringVar(&wandbNamespace, "wandb-namespace", "wandb", "Namespace of the W&B instance")
+	cmd.Flags().StringVar(&wandbVersion, "wandb-version", "", "Target server manifest version (e.g., 0.78.0) (required)")
+	cmd.Flags().BoolVar(&wait, "wait", false, "Wait for the W&B instance to be ready after applying")
+	cmd.Flags().DurationVar(&timeout, "timeout", 30*time.Minute, "Timeout when --wait is set")
+	cmd.Flags().BoolVar(&force, "force", false, "Allow downgrades and unparseable versions")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Show what would change without applying")
+
+	return cmd
+}
+
+func isDowngrade(current, target string) (bool, error) {
+	cur, err := semver.NewVersion(current)
+	if err != nil {
+		return false, fmt.Errorf("current version %q is not semver: %w", current, err)
+	}
+	tgt, err := semver.NewVersion(target)
+	if err != nil {
+		return false, fmt.Errorf("target version %q is not semver: %w", target, err)
+	}
+	return tgt.LessThan(cur), nil
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -579,7 +579,7 @@ func DeployOperator(
 		},
 		"wandb-operator": map[string]interface{}{
 			"image": map[string]interface{}{
-				"pullPolicy": "IfNotPresent", // todo - reminder: put back, local testing
+				"pullPolicy": "Always",
 			},
 		},
 		"telemetry": map[string]interface{}{

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -513,7 +513,12 @@ func installGatewayApiCRDs(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to fetch Gateway API CRDs: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func(Body io.ReadCloser) {
+		err := Body.Close()
+		if err != nil {
+
+		}
+	}(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to fetch Gateway API CRDs: status %s", resp.Status)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -574,7 +574,7 @@ func DeployOperator(
 		},
 		"wandb-operator": map[string]interface{}{
 			"image": map[string]interface{}{
-				"pullPolicy": "Always",
+				"pullPolicy": "IfNotPresent", // todo - reminder: put back, local testing
 			},
 		},
 		"telemetry": map[string]interface{}{
@@ -901,6 +901,33 @@ func ListCRs(ctx context.Context, namespace string) ([]string, error) {
 		names = append(names, item.GetName())
 	}
 	return names, nil
+}
+
+func GetCR(ctx context.Context, name, namespace string) (*v2.WeightsAndBiases, error) {
+	_, dyn, err := kubectl.GetDynamicClientset()
+	if err != nil {
+		return nil, err
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "apps.wandb.com",
+		Version:  "v2",
+		Resource: "weightsandbiases",
+	}
+
+	obj, err := dyn.Resource(gvr).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, fmt.Errorf("WeightsAndBiases %s/%s not found", namespace, name)
+		}
+		return nil, fmt.Errorf("failed to get WeightsAndBiases %s/%s: %w", namespace, name, err)
+	}
+
+	cr := &v2.WeightsAndBiases{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, cr); err != nil {
+		return nil, fmt.Errorf("failed to decode WeightsAndBiases: %w", err)
+	}
+	return cr, nil
 }
 
 // WaitForCR waits for WeightsAndBiases CR to be ready

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -513,12 +513,7 @@ func installGatewayApiCRDs(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to fetch Gateway API CRDs: %w", err)
 	}
-	defer func(Body io.ReadCloser) {
-		err := Body.Close()
-		if err != nil {
-
-		}
-	}(resp.Body)
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to fetch Gateway API CRDs: status %s", resp.Status)


### PR DESCRIPTION
WSM command to upgrade wandb version
Local testing demo - starting
```
$kubectl --context kind-wandb get wandb -n wandb wandb -o jsonpath='{.metadata.name}{" "}{.spec.wandb.version}{"\n"}'
wandb 0.78.0-pre.1772047260
```
Upgrade to 0.78.1
```
$wsm upgrade --context kind-wandb --wandb-version 0.78.1
Upgrade plan for wandb/wandb:
  spec.wandb.version: 0.78.0-pre.1772047260 → 0.78.1
Proceed? [y/N]: y
→ Applying upgrade... (0s)
Upgrade applied. Check status with: kubectl get wandb -n wandb wandb
```
Result
```
kubectl --context kind-wandb get wandb -n wandb wandb  -o jsonpath='{.metadata.name}{" "}{.spec.wandb.version}{"\n"}'
wandb 0.78.1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `deploy-v2` command for deploying W&B operator and instances with customizable networking, TLS, and sizing options.
  * Added `upgrade` command for managing W&B version updates with semver validation and downgrade protection.
  * Added local Kubernetes (Kind) cluster deployment support.
  * Added cloud cluster provisioning templates for AWS EKS, Azure AKS, and Google GKE via Terraform.

* **Documentation**
  * Comprehensive guides for installation, deployment, configuration, operations, and troubleshooting.
  * Platform-specific deployment walkthroughs for major cloud providers and local development.

* **Chores**
  * Updated Go toolchain and linting tools.
  * Refreshed dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wandb/wsm/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->