### PR TITLE
feat: Updating Operator functionalities

### DIFF
--- a/cmd/wsm/deploy_v2.go
+++ b/cmd/wsm/deploy_v2.go
@@ -127,6 +127,12 @@ func DeployV2Cmd() *cobra.Command {
 	cmd.PersistentFlags().String("license-file", "", "Path to W&B license file (optional, injected into spec.wandb.license)")
 	cmd.PersistentFlags().String("observability-mode", "off", "Enable observability for applications (off, full, forward)")
 	cmd.PersistentFlags().String("observability-forward-endpoint", "", "OTLP endpoint to forward telemetry to (required when --observability-mode=forward)")
+	cmd.PersistentFlags().String("observability-otel-secret", "", "Name of the OTEL connection secret (telemetry.otel.secretName; defaults to the chart's wandb-otel-connection; applied when --observability-mode=full|forward)")
+	cmd.PersistentFlags().String("observability-otel-protocol", "", "OTEL exporter protocol, e.g. http/protobuf or grpc (telemetry.otel.protocol; chart default if unset)")
+	cmd.PersistentFlags().String("observability-otel-service-name", "", "OTEL service.name resource attribute (telemetry.otel.serviceName; chart default if unset)")
+	cmd.PersistentFlags().String("observability-otel-resource-attributes", "", "Additional OTEL resource attributes, comma-separated key=value (telemetry.otel.resourceAttributes; chart default if unset)")
+	cmd.PersistentFlags().String("observability-forward-protocol", "", "OTLP forwarding protocol, e.g. http/protobuf or grpc (telemetry.forwarding.otlp.protocol; only applied when --observability-mode=forward)")
+	cmd.PersistentFlags().StringToString("observability-forward-headers", nil, "OTLP forwarding headers as key=value pairs, e.g. Authorization=Bearer... (telemetry.forwarding.otlp.headers; only applied when --observability-mode=forward)")
 	cmd.PersistentFlags().String("retention-policy", "detach", "Retention policy for W&B instance (detach, purge) - defaults to detach")
 	cmd.PersistentFlags().String("size", "small", "W&B instance size (dev, micro, small, medium, large, xlarge, xxlarge)")
 	cmd.PersistentFlags().String("wandb-hostname", "http://localhost:8080", "Hostname to use for the W&B instance")
@@ -356,6 +362,12 @@ func operatorDeployCmd() *cobra.Command {
 			licenseFile, _ := cmd.Flags().GetString("license-file")
 			telemetryMode, _ := cmd.Flags().GetString("observability-mode")
 			telemetryForwardEndpoint, _ := cmd.Flags().GetString("observability-forward-endpoint")
+			otelSecret, _ := cmd.Flags().GetString("observability-otel-secret")
+			otelProtocol, _ := cmd.Flags().GetString("observability-otel-protocol")
+			otelServiceName, _ := cmd.Flags().GetString("observability-otel-service-name")
+			otelResourceAttrs, _ := cmd.Flags().GetString("observability-otel-resource-attributes")
+			forwardProtocol, _ := cmd.Flags().GetString("observability-forward-protocol")
+			forwardHeaders, _ := cmd.Flags().GetStringToString("observability-forward-headers")
 			wandbNamespace, _ := cmd.Flags().GetString("wandb-namespace")
 			wandbVersion, _ := cmd.Flags().GetString("wandb-version")
 			wandbName, _ := cmd.Flags().GetString("wandb-name")
@@ -370,6 +382,17 @@ func operatorDeployCmd() *cobra.Command {
 			}
 			if err := validateNetworkingFlags(cmd.Flags().Changed("gateway-class"), gatewayClass, ingressClass); err != nil {
 				return err
+			}
+
+			telemetry := operator.TelemetryConfig{
+				Mode:              telemetryMode,
+				ForwardEndpoint:   telemetryForwardEndpoint,
+				OtelSecretName:    otelSecret,
+				OtelProtocol:      otelProtocol,
+				OtelServiceName:   otelServiceName,
+				OtelResourceAttrs: otelResourceAttrs,
+				ForwardProtocol:   forwardProtocol,
+				ForwardHeaders:    forwardHeaders,
 			}
 
 			err := processWandbCR(
@@ -404,8 +427,7 @@ func operatorDeployCmd() *cobra.Command {
 				includeCR,
 				wait,
 				clusterName,
-				telemetryMode,
-				telemetryForwardEndpoint,
+				telemetry,
 				wandbNamespace,
 				workers,
 				operatorChartVersion,
@@ -463,8 +485,7 @@ func performDeploy(
 	includeCR bool,
 	wait bool,
 	clusterName string,
-	telemetryMode string,
-	telemetryForwardEndpoint string,
+	telemetry operator.TelemetryConfig,
 	wandbNamespace string,
 	workers int,
 	operatorChartVersion string,
@@ -583,7 +604,7 @@ func performDeploy(
 	fmt.Printf("[%d/%d] Deploying Required operators...", currentStep, totalSteps)
 	start := time.Now()
 
-	if err := operator.DeployOperator(ctx, operatorNamespace, operatorChartVersion, operatorVersion, telemetryMode, telemetryForwardEndpoint, wandbNamespace); err != nil {
+	if err := operator.DeployOperator(ctx, operatorNamespace, operatorChartVersion, operatorVersion, telemetry, wandbNamespace); err != nil {
 		fmt.Println(" ✗")
 		return err
 	}

--- a/docs/configuration/customizing.md
+++ b/docs/configuration/customizing.md
@@ -57,6 +57,13 @@ wsm deploy-v2 wandb deploy \
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--observability-mode` | `off` | Telemetry mode for managed MySQL, Redis, Kafka, etc.: `off`, `full` (in-cluster Victoria + Grafana), or `forward` (Victoria stack + external OTLP forwarding) |
+| `--observability-forward-endpoint` | — | OTLP endpoint to forward telemetry to. Required when mode is `forward` |
+| `--observability-otel-secret` | — | OTEL connection secret name (`telemetry.otel.secretName`); chart default `wandb-otel-connection` if unset |
+| `--observability-otel-protocol` | — | OTEL exporter protocol, e.g. `http/protobuf` or `grpc` |
+| `--observability-otel-service-name` | — | OTEL `service.name` resource attribute |
+| `--observability-otel-resource-attributes` | — | Extra OTEL resource attributes, comma-separated `key=value` |
+| `--observability-forward-protocol` | — | OTLP forwarding protocol (forward mode only) |
+| `--observability-forward-headers` | — | OTLP forwarding headers, repeatable `key=value` (forward mode only) |
 | `--retention-policy` | `detach` | Behavior when deleting the CR: `detach` (leave infrastructure running) or `purge` (delete all managed resources and PVCs) |
 
 ## Using a Custom CR File
@@ -161,6 +168,21 @@ wsm deploy-v2 wandb deploy \
 ```
 
 This sets `telemetry.enabled: true` for MySQL, Redis, Kafka, Object Store, and ClickHouse.
+
+To forward OTLP data to an external collector instead of running Grafana locally, use `forward` mode. The OTEL/forwarding knobs below are optional — unset values fall back to the operator chart's defaults (`telemetry.otel.secretName` defaults to `wandb-otel-connection`, which the chart requires to be non-empty for `full`/`forward`):
+
+```bash
+wsm deploy-v2 operator \
+  --context <ctx> \
+  --observability-mode forward \
+  --observability-forward-endpoint otel-collector.example.com:4317 \
+  --observability-forward-protocol grpc \
+  --observability-forward-headers Authorization="Bearer $TOKEN" \
+  --observability-otel-secret my-otel-connection \
+  --observability-otel-service-name wandb-prod
+```
+
+The OTEL/forwarding flags are consumed by `wsm deploy-v2 operator` (they configure the operator chart); `--observability-mode` additionally toggles per-service telemetry on the CR.
 
 ## Retention Policies
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -75,6 +75,12 @@ wsm deploy-v2 wandb deploy [flags]
 | `--add-ingress-annotations` | `false` | Add AWS load-balancer annotations to the managed Gateway (**Gateway API mode only**; ignored in Ingress mode) |
 | `--observability-mode` | `off` | Telemetry mode: `off`, `full` (in-cluster Victoria Metrics stack **+ local Grafana**), or `forward` (Victoria stack + forward OTLP externally) |
 | `--observability-forward-endpoint` | — | OTLP endpoint to forward telemetry to. **Required** when `--observability-mode=forward` |
+| `--observability-otel-secret` | — | Name of the OTEL connection secret (`telemetry.otel.secretName`). Chart default `wandb-otel-connection` if unset. Applied when mode is `full` or `forward` |
+| `--observability-otel-protocol` | — | OTEL exporter protocol, e.g. `http/protobuf` or `grpc` (`telemetry.otel.protocol`). Chart default if unset |
+| `--observability-otel-service-name` | — | OTEL `service.name` resource attribute (`telemetry.otel.serviceName`). Chart default if unset |
+| `--observability-otel-resource-attributes` | — | Additional OTEL resource attributes, comma-separated `key=value` (`telemetry.otel.resourceAttributes`). Chart default if unset |
+| `--observability-forward-protocol` | — | OTLP forwarding protocol, e.g. `http/protobuf` or `grpc` (`telemetry.forwarding.otlp.protocol`). Only applied when `--observability-mode=forward` |
+| `--observability-forward-headers` | — | OTLP forwarding headers as repeatable `key=value` pairs, e.g. `Authorization=Bearer …` (`telemetry.forwarding.otlp.headers`). Only applied when `--observability-mode=forward` |
 | `--retention-policy` | `detach` | Behavior on CR deletion: `detach` (leave infrastructure running) or `purge` (delete all managed resources and PVCs) |
 | `--wait` | `false` | Wait for the W&B instance to report Ready |
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/docker/go-connections v0.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.10.2
-	github.com/wandb/operator v1.21.3-0.20260602214520-47e3cfd954e7
+	github.com/wandb/operator v1.21.3-0.20260611200416-80f51a441d6e
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.20.2
 	helm.sh/helm/v4 v4.1.4

--- a/go.sum
+++ b/go.sum
@@ -428,8 +428,8 @@ github.com/vbatts/tar-split v0.12.2 h1:w/Y6tjxpeiFMR47yzZPlPj/FcPLpXbTUi/9H7d3CP
 github.com/vbatts/tar-split v0.12.2/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vbauerster/mpb/v8 v8.10.2 h1:2uBykSHAYHekE11YvJhKxYmLATKHAGorZwFlyNw4hHM=
 github.com/vbauerster/mpb/v8 v8.10.2/go.mod h1:+Ja4P92E3/CorSZgfDtK46D7AVbDqmBQRTmyTqPElo0=
-github.com/wandb/operator v1.21.3-0.20260602214520-47e3cfd954e7 h1:Sb8x4sxBl0IixY6H7SAsrSQFQwsCZ5QVjw1LE3x08W4=
-github.com/wandb/operator v1.21.3-0.20260602214520-47e3cfd954e7/go.mod h1:N55MPyLHkpCEp0a3Kml4oV80iaBixYFDCu+s2/TWDaA=
+github.com/wandb/operator v1.21.3-0.20260611200416-80f51a441d6e h1:4ZP1UOcRlebhTDs26cgUOylcrxHO6AGY5Cyubi0hy2s=
+github.com/wandb/operator v1.21.3-0.20260611200416-80f51a441d6e/go.mod h1:N55MPyLHkpCEp0a3Kml4oV80iaBixYFDCu+s2/TWDaA=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -82,6 +82,20 @@ func ValidTelemetryMode(mode string) bool {
 	}
 }
 
+// TelemetryConfig bundles the operator-chart telemetry values wsm sets. Every
+// field except Mode is optional; an empty/zero field is omitted from the chart
+// values so the operator chart's own default for that key is preserved.
+type TelemetryConfig struct {
+	Mode              string
+	ForwardEndpoint   string
+	OtelSecretName    string
+	OtelProtocol      string
+	OtelServiceName   string
+	OtelResourceAttrs string
+	ForwardProtocol   string
+	ForwardHeaders    map[string]string
+}
+
 var (
 	apiDiscoveryRetryInterval = 2 * time.Second
 	apiDiscoveryRetryTimeout  = 2 * time.Minute
@@ -552,8 +566,7 @@ func DeployOperator(
 	namespace string,
 	chartVersion string,
 	operatorVersion string,
-	telemetryMode string,
-	telemetryForwardEndpoint string,
+	telemetry TelemetryConfig,
 	wandbNamespace string,
 ) error {
 	const repositoryURL = "oci://us-docker.pkg.dev/wandb-production/public/wandb/charts"
@@ -586,7 +599,26 @@ func DeployOperator(
 	}
 
 	telemetryValues := map[string]interface{}{
-		"mode": telemetryMode,
+		"mode": telemetry.Mode,
+	}
+	// Only set otelemetry.* keys the user supplied; leaving a key unset preserves the
+	// chart default (notably otelemetry.secretName, which telemetry-validation requires
+	// non-empty for full/forward).
+	otel := map[string]interface{}{}
+	if telemetry.OtelSecretName != "" {
+		otel["secretName"] = telemetry.OtelSecretName
+	}
+	if telemetry.OtelProtocol != "" {
+		otel["protocol"] = telemetry.OtelProtocol
+	}
+	if telemetry.OtelServiceName != "" {
+		otel["serviceName"] = telemetry.OtelServiceName
+	}
+	if telemetry.OtelResourceAttrs != "" {
+		otel["resourceAttributes"] = telemetry.OtelResourceAttrs
+	}
+	if len(otel) > 0 {
+		telemetryValues["otel"] = otel
 	}
 	releaseValues := map[string]interface{}{
 		"wandb": map[string]interface{}{
@@ -606,7 +638,7 @@ func DeployOperator(
 	// conditions are boolean-only). "full" runs the in-cluster Victoria stack
 	// plus local Grafana; "forward" runs the Victoria stack and forwards OTLP
 	// data to telemetry.forwarding.otlp.endpoint.
-	if telemetryMode == TelemetryModeFull || telemetryMode == TelemetryModeForward {
+	if telemetry.Mode == TelemetryModeFull || telemetry.Mode == TelemetryModeForward {
 		// The telemetry subchart deploys into the telemetry namespace (the W&B
 		// namespace), not the operator's release namespace. It must already
 		// exist — the chart does not create it — so ensure it here and pin
@@ -616,16 +648,29 @@ func DeployOperator(
 			return fmt.Errorf("failed to ensure telemetry namespace %q: %w", wandbNamespace, err)
 		}
 	}
-	switch telemetryMode {
+	switch telemetry.Mode {
 	case TelemetryModeFull:
 		releaseValues["victoria-metrics-operator"] = map[string]interface{}{"enabled": true}
 		releaseValues["grafana-operator"] = map[string]interface{}{"enabled": true}
 	case TelemetryModeForward:
 		releaseValues["victoria-metrics-operator"] = map[string]interface{}{"enabled": true}
+		otlp := map[string]interface{}{
+			"endpoint": telemetry.ForwardEndpoint,
+		}
+		if telemetry.ForwardProtocol != "" {
+			otlp["protocol"] = telemetry.ForwardProtocol
+		}
+		if len(telemetry.ForwardHeaders) > 0 {
+			// Helm coalesces and schema-validates values as map[string]interface{};
+			// a map[string]string trips its type detector ("invalid jsonType").
+			headers := make(map[string]interface{}, len(telemetry.ForwardHeaders))
+			for k, v := range telemetry.ForwardHeaders {
+				headers[k] = v
+			}
+			otlp["headers"] = headers
+		}
 		telemetryValues["forwarding"] = map[string]interface{}{
-			"otlp": map[string]interface{}{
-				"endpoint": telemetryForwardEndpoint,
-			},
+			"otlp": otlp,
 		}
 	}
 


### PR DESCRIPTION
- Bump wandb/operator dependency to origin/v2 (80f51a4)
- Add telemetry OTEL flags: `--observability-otel-secret` / `-protocol` / `-service-name` / `-resource-attributes`
- Add OTLP forwarding flags: `--observability-forward-protocol` / `-headers`
- Update command and configuration reference docs for the new flags

Verified on Kind: off / full / forward installs, and a full→off upgrade tears down the telemetry stack cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)