### PR TITLE
docs: complete RHEL install steps (git, Docker on RHEL 9) + quickstart kubectl/troubleshooting

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -31,7 +31,7 @@ On RHEL/CentOS 9:
 sudo dnf config-manager --enable codeready-builder-for-rhel-9-rhui-rpms  # AWS RHUI
 # Or for non-cloud RHEL: sudo dnf config-manager --enable crb
 
-sudo dnf install -y pkgconfig gpgme-devel gcc
+sudo dnf install -y pkgconfig gpgme-devel gcc git
 
 # go-toolset from RHEL repos is too old; install Go from the official release
 curl -LO https://go.dev/dl/go1.26.0.linux-amd64.tar.gz
@@ -39,6 +39,14 @@ sudo rm -rf /usr/local/go
 sudo tar -C /usr/local -xzf go1.26.0.linux-amd64.tar.gz
 echo 'export PATH=/usr/local/go/bin:$PATH' >> ~/.bashrc
 export PATH=/usr/local/go/bin:$PATH
+
+# Kind requires Docker as its container runtime (RHEL ships podman, which is not sufficient)
+sudo dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+sudo dnf install -y docker-ce docker-ce-cli containerd.io --allowerasing
+sudo systemctl enable --now docker
+sudo usermod -aG docker $USER
+# Log out and back in for the docker group to take effect.
+# RHEL 9 defaults to cgroup v2, so no grubby/reboot step is needed.
 ```
 
 On RHEL/CentOS 8:
@@ -47,7 +55,7 @@ On RHEL/CentOS 8:
 sudo dnf config-manager --enable codeready-builder-for-rhel-8-rhui-rpms  # AWS RHUI
 # Or for non-cloud RHEL: sudo dnf config-manager --enable powertools
 
-sudo dnf install -y pkgconfig gpgme-devel gcc
+sudo dnf install -y pkgconfig gpgme-devel gcc git
 
 # go-toolset from RHEL repos is too old; install Go from the official release
 curl -LO https://go.dev/dl/go1.26.0.linux-amd64.tar.gz

--- a/docs/getting-started/quickstart-kind.md
+++ b/docs/getting-started/quickstart-kind.md
@@ -100,6 +100,8 @@ kubectl --context kind-wandb delete apiservice v1beta1.metrics.k8s.io
 wsm deploy-v2 operator --include-cr --size dev --context kind-wandb
 ```
 
+> **Temporary workaround.** The underlying issue is fixed in `fix/handle-partial-api-discovery-in-gateway-crd-check` (stops installing metrics-server and tolerates partial API discovery); once that lands, this section can be removed.
+
 ## Next Steps
 
 - Customize the deployment: [SSL / TLS Configuration](../configuration/ssl-tls.md)

--- a/docs/getting-started/quickstart-kind.md
+++ b/docs/getting-started/quickstart-kind.md
@@ -15,7 +15,8 @@ Running the quick-start command will automatically create and configure:
 ## Prerequisites
 
 - [WSM installed](./installation.md)
-- [Docker](https://docs.docker.com/get-docker/) running
+- [Docker](https://docs.docker.com/get-docker/) running — Kind uses Docker as its container runtime. **Podman is not sufficient.** On RHEL/CentOS, Docker is not installed by default; see [Installation → Linux Dependencies](./installation.md#linux-dependencies) for setup.
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) — used by the [Monitor the Deployment](#monitor-the-deployment) steps below.
 - Port `8080` and `8443` available on your machine
 
 ## Deploy
@@ -80,6 +81,24 @@ The quick-start deployment uses these defaults:
 | **Size** | `small` |
 | **Version** | `0.79.2` (latest stable) |
 | **Gateway Class** | `nginx` |
+
+## Troubleshooting
+
+### Deploy fails: `stale GroupVersion discovery: metrics.k8s.io/v1beta1`
+
+If the deploy aborts at the gateway-API CRD check with:
+
+```
+failed to check if gateway api crds exist: unable to retrieve the complete list of
+server APIs: metrics.k8s.io/v1beta1: stale GroupVersion discovery: metrics.k8s.io/v1beta1
+```
+
+the cluster's metrics-server `APIService` is registered but not yet `Available`, so API discovery returns a partial result. Remove the unavailable aggregated API and re-run against the existing cluster (omit `--setup-k8s-cluster` so it isn't recreated):
+
+```bash
+kubectl --context kind-wandb delete apiservice v1beta1.metrics.k8s.io
+wsm deploy-v2 operator --include-cr --size dev --context kind-wandb
+```
 
 ## Next Steps
 


### PR DESCRIPTION
Builds on `rhel-fix`. Found while installing Operator v2 / WSM end-to-end on a fresh RHEL 9 box (self-managed-customer dry-run). The RHEL prereqs added in `rhel-fix` get you most of the way, but a verbatim run still hits these gaps:

**`installation.md`**
- Add `git` to the RHEL 8 + RHEL 9 `dnf install` lines — a fresh RHEL box has no git, so the first build step (`git clone`) fails with `git: command not found`.
- Add the `docker-ce` install block to the RHEL **9** section. RHEL 8 installs Docker but RHEL 9 omits it — yet kind needs Docker, not podman. RHEL 9 defaults to cgroup v2, so (unlike RHEL 8) no grubby/reboot is needed.

**`quickstart-kind.md`**
- Add `kubectl` to Prerequisites — the *Monitor the Deployment* commands need it, but nothing installs it.
- Clarify the Docker prereq (Podman is not sufficient; link to RHEL setup).
- Add a Troubleshooting entry for the `stale GroupVersion discovery: metrics.k8s.io/v1beta1` failure at the gateway-CRD check, with the delete-apiservice + re-run workaround. (Underlying code fix lives on `fix/handle-partial-api-discovery-in-gateway-crd-check`.)

Verified: with these steps a fresh RHEL 9 box builds WSM and reaches a working W&B instance at `localhost:8080`.

Draft for @dgreeninger-wandb to review, since it extends the rhel-fix doc work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
