### PR TITLE
Add OIDC config flags to deploy-v2

### DIFF
--- a/cmd/wsm/deploy_v2.go
+++ b/cmd/wsm/deploy_v2.go
@@ -1051,7 +1051,8 @@ func processWandbCR(
 		}
 	}
 
-	// Each OIDC leaf is <secret-name>:<key>; empty leaves stay zero and get
+	// Each OIDC leaf is <secret-name>:<key>. --cr-file wins: a leaf it already set
+	// is left alone (the flag for it is ignored). Empty leaves stay zero and get
 	// stripped by operator.ApplyCR when none is configured (stripFieldsNotInCRDSchema).
 	oidcRefs := []struct {
 		value string
@@ -1065,6 +1066,10 @@ func processWandbCR(
 	}
 	for _, ref := range oidcRefs {
 		if ref.value == "" {
+			continue
+		}
+		if ref.field.Name != "" || ref.field.Key != "" {
+			fmt.Printf("ignoring %s: spec.wandb.oidc value already set by --cr-file\n", ref.flag)
 			continue
 		}
 		secretName, key, ok := strings.Cut(ref.value, ":")

--- a/cmd/wsm/deploy_v2.go
+++ b/cmd/wsm/deploy_v2.go
@@ -139,6 +139,13 @@ func DeployV2Cmd() *cobra.Command {
 	cmd.PersistentFlags().String("wandb-name", "wandb", "Name of the W&B instance")
 	cmd.PersistentFlags().String("wandb-version", "", "Server manifest version (e.g., 0.76.1)")
 	cmd.PersistentFlags().String("wandb-namespace", "wandb", "Namespace for CR")
+	cmd.PersistentFlags().String("oidc-client-id", "", "OIDC client ID as <secret-name>:<key> (spec.wandb.oidc.clientId; optional)")
+	cmd.PersistentFlags().String("oidc-client-secret", "", "OIDC client secret as <secret-name>:<key> (spec.wandb.oidc.clientSecret; optional)")
+	cmd.PersistentFlags().String("oidc-issuer-url", "", "OIDC issuer URL as <secret-name>:<key> (spec.wandb.oidc.issuerUrl; optional)")
+	cmd.PersistentFlags().String("oidc-auth-method", "", "OIDC auth method as <secret-name>:<key> (spec.wandb.oidc.authMethod; optional)")
+	// TODO(operator-bump): add --oidc-session-length once OidcSpec.SessionLength
+	// exists upstream; set it in processWandbCR (maps to app env
+	// GORILLA_SESSION_LENGTH, operator default 720h).
 	// TODO readd this when the CR reports ready properly
 	//cmd.Flags().Bool("wait", false, "Wait for the W&B instance to be ready (status.ready == true)")
 
@@ -274,6 +281,10 @@ func wandbCreateCmd() *cobra.Command {
 			wandbVersion, _ := cmd.Flags().GetString("wandb-version")
 			wandbName, _ := cmd.Flags().GetString("wandb-name")
 			wandbHostname, _ := cmd.Flags().GetString("wandb-hostname")
+			oidcClientID, _ := cmd.Flags().GetString("oidc-client-id")
+			oidcClientSecret, _ := cmd.Flags().GetString("oidc-client-secret")
+			oidcIssuerURL, _ := cmd.Flags().GetString("oidc-issuer-url")
+			oidcAuthMethod, _ := cmd.Flags().GetString("oidc-auth-method")
 			wait, _ := cmd.Flags().GetBool("wait")
 
 			if err := validateObservabilityMode(telemetryMode); err != nil {
@@ -302,6 +313,10 @@ func wandbCreateCmd() *cobra.Command {
 				createCA,
 				size,
 				retentionPolicy,
+				oidcClientID,
+				oidcClientSecret,
+				oidcIssuerURL,
+				oidcAuthMethod,
 			)
 			if err != nil {
 				return err
@@ -373,6 +388,10 @@ func operatorDeployCmd() *cobra.Command {
 			wandbVersion, _ := cmd.Flags().GetString("wandb-version")
 			wandbName, _ := cmd.Flags().GetString("wandb-name")
 			wandbHostname, _ := cmd.Flags().GetString("wandb-hostname")
+			oidcClientID, _ := cmd.Flags().GetString("oidc-client-id")
+			oidcClientSecret, _ := cmd.Flags().GetString("oidc-client-secret")
+			oidcIssuerURL, _ := cmd.Flags().GetString("oidc-issuer-url")
+			oidcAuthMethod, _ := cmd.Flags().GetString("oidc-auth-method")
 			wait, _ := cmd.Flags().GetBool("wait")
 
 			if err := validateObservabilityMode(telemetryMode); err != nil {
@@ -413,6 +432,10 @@ func operatorDeployCmd() *cobra.Command {
 				createCA,
 				size,
 				retentionPolicy,
+				oidcClientID,
+				oidcClientSecret,
+				oidcIssuerURL,
+				oidcAuthMethod,
 			)
 			if err != nil {
 				return err
@@ -983,6 +1006,10 @@ func processWandbCR(
 	createCA bool,
 	size string,
 	retentionPolicy string,
+	oidcClientID string,
+	oidcClientSecret string,
+	oidcIssuerURL string,
+	oidcAuthMethod string,
 ) error {
 	if crFile != "" {
 		var err error
@@ -1021,6 +1048,32 @@ func processWandbCR(
 				return err
 			}
 			wandbCR.Spec.Wandb.License = strings.TrimSpace(string(licenseData))
+		}
+	}
+
+	// Each OIDC leaf is <secret-name>:<key>; empty leaves stay zero and get
+	// stripped by operator.ApplyCR when none is configured (stripFieldsNotInCRDSchema).
+	oidcRefs := []struct {
+		value string
+		field *corev1.SecretKeySelector
+		flag  string
+	}{
+		{oidcClientID, &wandbCR.Spec.Wandb.OIDC.ClientId, "--oidc-client-id"},
+		{oidcClientSecret, &wandbCR.Spec.Wandb.OIDC.ClientSecret, "--oidc-client-secret"},
+		{oidcIssuerURL, &wandbCR.Spec.Wandb.OIDC.IssuerUrl, "--oidc-issuer-url"},
+		{oidcAuthMethod, &wandbCR.Spec.Wandb.OIDC.AuthMethod, "--oidc-auth-method"},
+	}
+	for _, ref := range oidcRefs {
+		if ref.value == "" {
+			continue
+		}
+		secretName, key, ok := strings.Cut(ref.value, ":")
+		if !ok || secretName == "" || key == "" {
+			return fmt.Errorf("%s must be in <secret-name>:<key> form, got %q", ref.flag, ref.value)
+		}
+		*ref.field = corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: secretName},
+			Key:                  key,
 		}
 	}
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -67,7 +67,7 @@ wsm deploy-v2 wandb deploy [flags]
 | `--size` | `small` | Deployment size profile: `dev`, `micro`, `small`, `medium`, `large`, `xlarge`, `xxlarge` |
 | `--license` | — | W&B license string |
 | `--license-file` | — | Path to a file containing the W&B license |
-| `--oidc-client-id` | — | OIDC client ID as `<secret-name>:<key>` (`spec.wandb.oidc.clientId`). Optional; leave unset to disable OIDC |
+| `--oidc-client-id` | — | OIDC client ID as `<secret-name>:<key>` (`spec.wandb.oidc.clientId`). Optional; leave unset to disable OIDC. Ignored for any leaf already set via `--cr-file` |
 | `--oidc-client-secret` | — | OIDC client secret as `<secret-name>:<key>` (`spec.wandb.oidc.clientSecret`) |
 | `--oidc-issuer-url` | — | OIDC issuer URL as `<secret-name>:<key>` (`spec.wandb.oidc.issuerUrl`) |
 | `--oidc-auth-method` | — | OIDC auth method as `<secret-name>:<key>` (`spec.wandb.oidc.authMethod`) |

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -67,6 +67,10 @@ wsm deploy-v2 wandb deploy [flags]
 | `--size` | `small` | Deployment size profile: `dev`, `micro`, `small`, `medium`, `large`, `xlarge`, `xxlarge` |
 | `--license` | — | W&B license string |
 | `--license-file` | — | Path to a file containing the W&B license |
+| `--oidc-client-id` | — | OIDC client ID as `<secret-name>:<key>` (`spec.wandb.oidc.clientId`). Optional; leave unset to disable OIDC |
+| `--oidc-client-secret` | — | OIDC client secret as `<secret-name>:<key>` (`spec.wandb.oidc.clientSecret`) |
+| `--oidc-issuer-url` | — | OIDC issuer URL as `<secret-name>:<key>` (`spec.wandb.oidc.issuerUrl`) |
+| `--oidc-auth-method` | — | OIDC auth method as `<secret-name>:<key>` (`spec.wandb.oidc.authMethod`) |
 | `--gateway-class` | `nginx` | Gateway class name (selects Gateway API mode; the default). Mutually exclusive with `--ingress-class` |
 | `--ingress-class` | — | Ingress class name (selects Ingress mode). Takes precedence over the default `--gateway-class`; setting both explicitly is an error |
 | `--ingress-name` | — | Override the generated Ingress resource name (defaults to the CR name) |

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -1030,12 +1030,36 @@ func stripFieldsNotInCRDSchema(obj *unstructured.Unstructured) {
 	// .status is always operator-owned; never SSA from the client side.
 	unstructured.RemoveNestedField(obj.Object, "status")
 
-	// OidcSpec is a by-value struct in the v2 Go API, so Go's `omitempty`
-	// does not drop a zero value — wsm would emit oidc.{clientId,clientSecret,
-	// issuerUrl,authMethod}: {"key": ""} on every apply even when no OIDC is
-	// configured. Drop the whole oidc block; wsm has no flag for it, so a
-	// user with OIDC needs --cr-file regardless.
-	unstructured.RemoveNestedField(obj.Object, "spec", "wandb", "oidc")
+	// OidcSpec is a by-value struct, so `omitempty` can't drop its zero value
+	// (serializes as oidc.*: {"key": ""}). Strip it unless a leaf is set, so
+	// configured OIDC (flags or --cr-file) still reaches the CRD.
+	// TODO(operator-bump): drop this once OidcSpec is a pointer upstream — the
+	// alpha.2 CRD already tolerates the empty block (verified on Kind).
+	if !oidcConfigured(obj) {
+		unstructured.RemoveNestedField(obj.Object, "spec", "wandb", "oidc")
+	}
+}
+
+// oidcConfigured reports whether spec.wandb.oidc has any leaf selector with a
+// non-empty name or key (a real reference, not the zero-value struct).
+func oidcConfigured(obj *unstructured.Unstructured) bool {
+	oidc, found, err := unstructured.NestedMap(obj.Object, "spec", "wandb", "oidc")
+	if err != nil || !found {
+		return false
+	}
+	for _, leaf := range oidc {
+		selector, ok := leaf.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if name, _, _ := unstructured.NestedString(selector, "name"); name != "" {
+			return true
+		}
+		if key, _, _ := unstructured.NestedString(selector, "key"); key != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // DeleteCR deletes a WeightsAndBiases CR from the cluster


### PR DESCRIPTION
Adds four flags to `deploy-v2` for OIDC config, each taking `<secret-name>:<key>`:

- `--oidc-client-id` → `spec.wandb.oidc.clientId`
- `--oidc-client-secret` → `spec.wandb.oidc.clientSecret`
- `--oidc-issuer-url` → `spec.wandb.oidc.issuerUrl`
- `--oidc-auth-method` → `spec.wandb.oidc.authMethod`

These are references to an existing Secret (`<secret-name>:<key>`), not values — no credential touches the CLI or the CR, which only stores `{name, key}`.

`ApplyCR` previously stripped the whole `oidc` block on every apply (the by-value `OidcSpec` can't be dropped by `omitempty`, so an empty one serialized as `{"key":""}`). It's now stripped only when unconfigured, so configured OIDC survives.

You can also set OIDC via `--cr-file` if you prefer — same as external infra. `--cr-file` takes precedence: a leaf it sets is left alone and the matching flag is ignored, so the flags are just a convenience shortcut over the file.

`--oidc-session-length` will be a fast follow until operator chart gets updated - marked with `TODO`.