### PR TITLE
Merge main into operator-v2 (resolve conflicts)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jsbroks @dacbd @zacharyblasczyk @j7m4 @danielpanzella @adityachoudhari26 @theishshah @mwhooker
+* @wandb/on-prem-team

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>wandb/renovate-config"]
+}

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,9 +11,9 @@ jobs:
     name: Setup Dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: 1.24
           cache: true
@@ -28,9 +28,9 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: 1.24
           cache: true
@@ -38,7 +38,7 @@ jobs:
       - name: Install gpgme dependencies
         run: sudo apt-get update && sudo apt-get install -y libgpgme-dev
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           version: v1.64.5
           args: --timeout=5m
@@ -48,9 +48,9 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: 1.24
           cache: true
@@ -65,9 +65,9 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: 1.24
       - name: Check for changes in go.mod or go.sum

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,0 +1,44 @@
+name: GoReleaser
+
+# Reusable build: builds binaries + archives and cuts a same-repo GitHub
+# release with GoReleaser. Same-repo releases only need the built-in
+# GITHUB_TOKEN (contents: write) — no PAT required. Called by release.yaml
+# (manual tag pushes) and release-on-merge.yaml (auto tags on merge to main).
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref (tag) to build. Empty uses the triggering ref.
+        type: string
+        required: false
+        default: ""
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'wandb'
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: 1.24
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Install dependencies
+        run: go mod download
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-on-merge.yaml
+++ b/.github/workflows/release-on-merge.yaml
@@ -1,0 +1,78 @@
+name: Release on merge
+
+# Every PR merged into main cuts a release. The bump is chosen by a label on
+# the PR (read straight from the event payload — no API call, no token):
+#   release:major  -> vX+1.0.0
+#   release:minor  -> vX.Y+1.0
+#   release:patch  -> vX.Y.Z+1   (default when no label is set)
+#   release:skip   -> no release
+# The tag is pushed with the built-in GITHUB_TOKEN and the shared reusable
+# GoReleaser workflow builds the release, so no PAT is needed.
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true && github.repository_owner == 'wandb'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push the tag
+    outputs:
+      new_tag: ${{ steps.tag.outputs.new_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Pick bump from PR label
+        id: bump
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if   grep -q '"release:skip"'  <<<"$LABELS"; then level=skip
+          elif grep -q '"release:major"' <<<"$LABELS"; then level=major
+          elif grep -q '"release:minor"' <<<"$LABELS"; then level=minor
+          else level=patch; fi
+          echo "level=$level" >>"$GITHUB_OUTPUT"
+          echo "Bump level: $level"
+
+      - name: Create and push tag
+        id: tag
+        if: steps.bump.outputs.level != 'skip'
+        run: |
+          git config user.name  'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          latest=$(git describe --tags --abbrev=0 --match "v[0-9]*.[0-9]*.[0-9]*" 2>/dev/null || echo v0.0.0)
+          IFS='.' read -r major minor patch <<<"${latest#v}"
+          patch="${patch%%-*}" # strip any pre-release suffix to keep arithmetic safe
+          major=${major:-0}; minor=${minor:-0}; patch=${patch:-0}
+          case "${{ steps.bump.outputs.level }}" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+          new_tag="v${major}.${minor}.${patch}"
+          git tag -a "$new_tag" -m "$new_tag"
+          git push origin "$new_tag"
+          echo "new_tag=$new_tag" >>"$GITHUB_OUTPUT"
+          echo "Tagged $new_tag"
+
+  release:
+    needs: tag
+    if: needs.tag.outputs.new_tag != ''
+    permissions:
+      contents: write
+    uses: ./.github/workflows/goreleaser.yaml
+    with:
+      ref: ${{ needs.tag.outputs.new_tag }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,9 @@
 name: Release
 
+# Manual escape hatch: pushing a tag by hand cuts a release via the shared
+# GoReleaser build. Automatic releases on merge to main are handled by
+# release-on-merge.yaml, which calls the same reusable workflow.
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -14,25 +18,5 @@ on:
       - "*"
 
 jobs:
-  linux:
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'wandb'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
-        with:
-          go-version: 1.24
-          cache: true
-          cache-dependency-path: go.sum
-      - name: Install dependencies
-        run: go get ./...
-      - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5
-        with:
-          distribution: goreleaser
-          version: "~> v2"
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+  release:
+    uses: ./.github/workflows/goreleaser.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,9 +19,9 @@ jobs:
     if: github.repository_owner == 'wandb'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: 1.24
           cache: true
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: go get ./...
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ cmd/wsm/bundle/
 
 bundle/
 
-wsm
+# Anchored to repo root: the built binary is ./wsm. An unanchored `wsm` would
+# also match the cmd/wsm/ directory and silently ignore new files added there.
+/wsm
 
 test-wsm/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,6 +27,11 @@ builds:
     tags:
     - containers_image_openpgp
     main: ./cmd/wsm
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
 
 archives:
   - format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,14 @@ ifeq ($(shell uname),Darwin)
 	export LDFLAGS=-w
 endif
 
+# Version stamp for local builds; CI releases are stamped by GoReleaser instead.
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
+DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+GO_LDFLAGS = -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
+
 build:
-	go build -o wsm ./cmd/wsm
+	go build -ldflags "$(GO_LDFLAGS)" -o wsm ./cmd/wsm
 
 # Modern linter installation
 install-lint:

--- a/README.md
+++ b/README.md
@@ -20,8 +20,24 @@ Basic commands to get started:
 wsm list
 wsm download
 wsm deploy
+wsm version   # print the build's version, commit, and date
 wsm --help
 ```
+
+## Releasing
+
+Releases are cut automatically when a PR is merged into `main` — no manual tagging needed.
+
+- The version bump is chosen by a label on the merged PR:
+  - `release:major` → `vX+1.0.0`
+  - `release:minor` → `vX.Y+1.0`
+  - `release:patch` (or no label) → `vX.Y.Z+1`
+  - `release:skip` → no release
+- The new tag is pushed and [GoReleaser](https://goreleaser.com) builds the binaries and
+  publishes the GitHub release. The version is baked into the binary — check it with
+  `wsm version`.
+- Need to cut one by hand? Push a tag (`git tag vX.Y.Z && git push origin vX.Y.Z`) and the
+  same build runs.
 
 ## Requirements
 

--- a/cmd/wsm/version.go
+++ b/cmd/wsm/version.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// These are populated at build time via -ldflags "-X main.version=... -X main.commit=... -X main.date=...".
+// GoReleaser injects them by default; local `make build` stamps a dev value.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func init() {
+	rootCmd.Version = version
+	rootCmd.AddCommand(VersionCmd())
+}
+
+func VersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the wsm version, commit, and build date",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("wsm %s (commit %s, built %s)\n", version, commit, date)
+		},
+	}
+}


### PR DESCRIPTION
Merges the latest `main` into `operator-v2` and resolves the merge conflicts, so that the follow-up `operator-v2 → main` PR (#82) can merge cleanly.

## Conflicts resolved (4 files)

- **`.github/workflows/checks.yaml`** — kept `golangci-lint-action@v7` (required for `golangci-lint v2.11.4`); dropped main's `@v6` SHA pin.
- **`.gitignore`** — kept main's explanatory comment above the shared `/wsm` entry.
- **`Makefile`** — combined both sides: OS-aware `INSTALL_DIR`/`BINARY` vars and the `install` target from `operator-v2`, plus main's version-stamping ldflags, into a single `build` command (`CGO_ENABLED=0`, `-tags containers_image_openpgp`, `-ldflags "$(GO_LDFLAGS)"`).
- **`README.md`** — kept `operator-v2`'s v2 on-prem / mirror-registry walkthrough for that section (`wsm version` remains documented in the Releasing section).

## Verification

- `make build` succeeds; the version-stamp ldflags work (`wsm version` prints version/commit/date).
- No conflict markers remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)