### PR TITLE
fix(ci): unblock Run Checks on operator-v2

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -11,11 +11,11 @@ jobs:
     name: Setup Dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
           cache-dependency-path: go.sum
       - name: Install dependencies
@@ -28,17 +28,17 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
           cache-dependency-path: go.sum
       - name: Install gpgme dependencies
         run: sudo apt-get update && sudo apt-get install -y libgpgme-dev
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: v2.11.4
           args: --timeout=5m
@@ -48,11 +48,11 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
           cache-dependency-path: go.sum
       - name: Format
@@ -65,11 +65,11 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
       - name: Check for changes in go.mod or go.sum
         run: |
           go mod tidy

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -22,20 +22,20 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref }}
       - name: Set up Go
-        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: 1.24
+          go-version: 1.26
           cache: true
           cache-dependency-path: go.sum
       - name: Install dependencies
         run: go mod download
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/release-on-merge.yaml
+++ b/.github/workflows/release-on-merge.yaml
@@ -30,7 +30,7 @@ jobs:
       new_tag: ${{ steps.tag.outputs.new_tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}

--- a/cmd/wsm/convert_v2.go
+++ b/cmd/wsm/convert_v2.go
@@ -70,8 +70,6 @@ what the in-cluster webhook would emit after upgrade.`,
 			}
 
 			return writeSplit(outputPath, wandbName, v1YAML, v2YAML)
-
-			return nil
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/containers/image/v5 v5.36.2
 	github.com/docker/go-connections v0.7.0
 	github.com/pkg/errors v0.9.1
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/spf13/cobra v1.10.2
 	github.com/wandb/operator v1.21.3-0.20260611200416-80f51a441d6e
 	gopkg.in/yaml.v3 v3.0.1
@@ -151,6 +150,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/proglottis/gpgme v0.1.4 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect


### PR DESCRIPTION
## What

Fixes the failing **Run Checks** CI on `operator-v2` (run `29383496048`, PR #82) and clears the Node 20 deprecation warnings.

## Failures fixed (verified from run logs, not inferred)

1. **golangci-lint** — `cmd/wsm/convert_v2.go:74:4: unreachable code (govet)`. Line 72 already `return writeSplit(...)`; deleted the dead `return nil`. `golangci-lint run` now reports **0 issues**.
2. **Dependency Check** — `go mod tidy` reclassifies `github.com/pmezard/go-difflib` from a direct to an indirect require, so `git diff --exit-code go.mod go.sum` failed. Ran tidy and committed the result (`go.sum` unchanged).

## Also addressed (asked about / stands out)

3. **Node.js 20 deprecation** — every action targeted Node 20 and was being force-run on Node 24. Bumped to Node-24 majors (SHA-pinned, matching the repo's Renovate style):
   - `actions/checkout` v4 → v5
   - `actions/setup-go` v5 → v6
   - `golangci/golangci-lint-action` v7 → v8 (still runs golangci-lint `v2.11.4`)
   - `goreleaser/goreleaser-action` v5 → v6
4. **Go version mismatch** — `go.mod` requires `go 1.26.3`, but CI pinned `1.25` (checks) / `1.24` (goreleaser). The older toolchains auto-downloaded 1.26.3 each run, and that download racing the `setup-go` cache produced the `tar ... Cannot open: File exists` / `Failed to restore` warnings. Bumped CI `go-version` to `1.26`.

## Verification

- `make build` ✓
- `go vet ./...` ✓
- `golangci-lint run --timeout=5m` → **0 issues** ✓
- `go mod tidy && git diff --exit-code go.mod go.sum` → clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)