### PR TITLE
fix(deploy-v2): cr-file compatibility with camelCase in CR YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ CR field reference: [`docs/reference/cr-fields.md`](./docs/reference/cr-fields.m
 | `wsm telemetry` | v2 | Open the in-cluster telemetry UIs (Grafana, VictoriaMetrics). |
 | `wsm set-version` | — | Set the version of a wsm-managed W&B instance. |
 | `wsm console` | v1 | Port-forward and open the W&B console in a browser. |
-| `wsm version` | — | Print the wsm version, commit, and build date. |
+| [`wsm version`](#wsm-version) | — | Print the wsm version, commit, and build date. |
 | [`wsm deploy`](#wsm-deploy) | v1 | Legacy three-phase install (operator → chart ConfigMap → v1 CR). |
 | [`wsm list`](#wsm-list) | v1 | List the container images a fresh install would pull. |
 | [`wsm download`](#wsm-download) | v1 | Build an air-gapped `./bundle/` (charts + images + spec). |
@@ -175,6 +175,20 @@ Download images and charts into a `./bundle/` for offline transfer. Requires
 ```bash
 wsm download [-p linux/amd64]
 ```
+
+---
+
+### `wsm version`
+
+Print the `wsm` version, git commit, and build date. Needs no cluster.
+
+```bash
+wsm version           # wsm v2.0.0 (commit 738c0b9, built 2026-07-17T…)
+wsm --version         # same value, cobra's built-in flag
+```
+
+Values are stamped at build time (GoReleaser on tagged releases; `make build`
+stamps a local `dev` build).
 
 ---
 

--- a/cmd/wsm/deploy_v2.go
+++ b/cmd/wsm/deploy_v2.go
@@ -25,6 +25,7 @@ import (
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/wandb/operator/api/v2"
+	sigsyaml "sigs.k8s.io/yaml"
 )
 
 func init() {
@@ -320,7 +321,7 @@ func wandbCreateCmd() *cobra.Command {
 
 			ctx := context.Background()
 
-			if err := processWandbCR(f); err != nil {
+			if err := processWandbCR(cmd, f); err != nil {
 				return err
 			}
 
@@ -400,7 +401,7 @@ func operatorDeployCmd() *cobra.Command {
 				return err
 			}
 
-			if err := processWandbCR(f); err != nil {
+			if err := processWandbCR(cmd, f); err != nil {
 				return err
 			}
 
@@ -1211,7 +1212,7 @@ func normalizeMirrorManifestSource(f *wandbCRFlags, willReconcile bool) error {
 	return nil
 }
 
-func processWandbCR(f wandbCRFlags) error {
+func processWandbCR(cmd *cobra.Command, f wandbCRFlags) error {
 	if f.crFile != "" {
 		var err error
 		wandbCR, err = readCRFile(f.crFile)
@@ -1221,10 +1222,21 @@ func processWandbCR(f wandbCRFlags) error {
 		}
 	}
 
-	wandbCR.Name = f.wandbName
-	wandbCR.Spec.Wandb.Hostname = f.wandbHostname
-	wandbCR.Spec.Size = v2.Size(f.size)
-	wandbCR.Spec.RetentionPolicy.OnDelete = v2.OnDeletePolicy(f.retentionPolicy)
+	// Apply each flag only when explicitly set; otherwise keep the CR-file value,
+	// falling back to the flag default (carried in f.*) when the file left it empty.
+	// Preserves the documented precedence: --cr-set > flags > --cr-file.
+	if cmd.Flags().Changed("wandb-name") || wandbCR.Name == "" {
+		wandbCR.Name = f.wandbName
+	}
+	if cmd.Flags().Changed("wandb-hostname") || wandbCR.Spec.Wandb.Hostname == "" {
+		wandbCR.Spec.Wandb.Hostname = f.wandbHostname
+	}
+	if cmd.Flags().Changed("size") || wandbCR.Spec.Size == "" {
+		wandbCR.Spec.Size = v2.Size(f.size)
+	}
+	if cmd.Flags().Changed("retention-policy") || wandbCR.Spec.RetentionPolicy.OnDelete == "" {
+		wandbCR.Spec.RetentionPolicy.OnDelete = v2.OnDeletePolicy(f.retentionPolicy)
+	}
 
 	if wandbCR.Spec.Wandb.Version == "" && f.wandbVersion == "" {
 		wandbCR.Spec.Wandb.Version = defaultWandbVersion
@@ -1444,9 +1456,9 @@ func readCRFile(crPath string) (*v2.WeightsAndBiases, error) {
 		return nil, fmt.Errorf("failed to read CR file: %w", err)
 	}
 	cr := &v2.WeightsAndBiases{}
-	err = yaml.Unmarshal(crData, cr)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse CR YAML: %w", err)
+	// Strict surfaces unknown/misspelled keys as errors instead of dropping them
+	if err := sigsyaml.UnmarshalStrict(crData, cr); err != nil {
+		return nil, fmt.Errorf("failed to parse CR YAML from %s: %w", crPath, err)
 	}
 	return cr, nil
 }

--- a/docs/configuration/customizing.md
+++ b/docs/configuration/customizing.md
@@ -112,25 +112,29 @@ spec:
   retentionPolicy:
     onDelete: detach
   mysql:
-    managedMysql:
-      telemetry:
-        enabled: true
+    default:
+      managedMysql:
+        telemetry:
+          enabled: true
   redis:
-    managedRedis:
-      telemetry:
-        enabled: true
+    default:
+      managedRedis:
+        telemetry:
+          enabled: true
   kafka:
     managedKafka:
       telemetry:
         enabled: true
   objectStore:
-    managedObjectStore:
-      telemetry:
-        enabled: true
+    default:
+      managedObjectStore:
+        telemetry:
+          enabled: true
   clickHouse:
-    managedClickHouse:
-      telemetry:
-        enabled: true
+    default:
+      managedClickHouse:
+        telemetry:
+          enabled: true
 ```
 
 ## Networking Modes

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -415,6 +415,21 @@ Each subcommand takes `--service` (override the resolved Service name), `--local
 
 ---
 
+## Utility Commands
+
+### `wsm version`
+
+Print the `wsm` version, git commit, and build date, then exit. Needs no cluster or `--context`.
+
+```bash
+wsm version
+# wsm v2.0.0 (commit 738c0b9, built 2026-07-17T21:23:14Z)
+```
+
+The values are stamped in at build time (GoReleaser on tagged releases; `make build` stamps a `dev` build locally). The version is also available as `wsm --version`.
+
+---
+
 ## Flag Precedence
 
 When multiple configuration sources specify the same value, the resolution order is:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -85,7 +85,7 @@ wsm deploy-v2 wandb deploy [flags]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--context` | — | **Required.** Name of the kubeconfig context to use |
-| `--cr-file` | — | Path to a custom WeightsAndBiases CR YAML file |
+| `--cr-file` | — | Path to a custom WeightsAndBiases CR YAML file. Validated strictly: unknown/misspelled fields error out |
 | `--wandb-name` | `wandb` | Name of the W&B instance |
 | `--wandb-namespace` | `wandb` | Kubernetes namespace for the CR |
 | `--wandb-hostname` | `http://localhost:8080` | External URL for accessing W&B |


### PR DESCRIPTION
# Summary of Changes

**Jira:** [ONPREM-XXXX](https://coreweave.atlassian.net/browse/ONPREM-XXXX)

`--cr-file` was effectively non-functional for a normally-authored CR: a standard camelCase file (as `kubectl get wandb -o yaml` or the CR reference docs produce) either hard-failed or had every multi-word field silently dropped. Root cause and fixes:

- **Parsing** — `readCRFile` used `gopkg.in/yaml.v3`, which keys off lowercased Go field names and ignores the operator v2 types' `json:"camelCase"` tags, so multi-word keys (`objectStore`, `manifestRepository`, `retentionPolicy`, …) were dropped and the inline `apiVersion`/`kind` failed to parse (hard fail). Switched to `sigs.k8s.io/yaml.UnmarshalStrict` (YAML→JSON→`json.Unmarshal`), the k8s-standard path that honors `json:` tags and `UnmarshalJSON` methods. Strict mode surfaces unknown/misspelled fields as errors instead of silently dropping them (the typed round-trip prunes unknown fields before apply, so the server can't catch them).
- **Flag precedence** — `--wandb-name`, `--wandb-hostname`, `--size`, `--retention-policy` were applied unconditionally, clobbering CR-file values with flag defaults. They now apply only when explicitly set (`cmd.Flags().Changed`), preserving the documented precedence `--cr-set` > flags > `--cr-file`.
- **Docs** — updated the `--cr-file` reference and fixed the customizing.md example (managed infra keyed under `default:`); also documented the previously-undocumented `wsm version` command in the reference and README.

# Test Plan

- `make build` — compiles clean
- `make lint` — go vet + golangci-lint, 0 issues
- `make fmt` — no diff
- `go mod tidy` — no diff
- **Kind smoke test (v2)** against a live operator + v2 CRD: a 29-assertion suite applying test CRs via `--cr-file`, reading back the server-stored spec, and deleting. All 29 pass:
  - Positive: 9 multi-word camelCase fields survive to the server; round-trip of the live `kubectl -o yaml` CR applies clean.
  - Negative: unknown fields / wrong types / malformed YAML error out with no apply; legacy lowercased keys still map (case-insensitive JSON match).
  - Precedence: CR-file values preserved when flags unset, flags win when set, defaults still apply on the no-`--cr-file` path; `--cr-set` beats `--cr-file`; sub-min version rejected; missing version defaulted.
  - Before/after: the pre-fix binary hard-fails on the same CR (`no matches for kind "" in version ""`); the fixed binary lands every field. Pre-existing `wandb/wandb` CR left untouched.

# Requirements

- [x] Lint clean (`make lint`)
- [x] Format clean (`make fmt` leaves no diff)
- [x] `go.mod` / `go.sum` tidy (`go mod tidy` leaves no diff)
- [x] I/AI have tested the changes on this PR
- [x] Docs (`docs/`, `docs/reference/commands.md`, `docs/reference/cr-fields.md`) / `CLAUDE.md` updated if behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `wsm version` and `wsm --version` commands, displaying the version, Git commit, and build date without requiring a cluster or context.

* **Bug Fixes**
  * Deployment configuration now reports errors for unknown or misspelled YAML fields.
  * Explicit command-line options are correctly prioritized over configuration file values.

* **Documentation**
  * Added command reference details and examples for version reporting.
  * Updated custom configuration examples for managed datastore telemetry settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->