### PR TITLE
fix: patch Grafana telemetry CRD validation

### DIFF
--- a/pkg/operator/grafana_crd_patch.go
+++ b/pkg/operator/grafana_crd_patch.go
@@ -1,0 +1,53 @@
+package operator
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+
+	helmchart "helm.sh/helm/v4/pkg/chart"
+	"helm.sh/helm/v4/pkg/chart/common"
+)
+
+const (
+	grafanaNotificationPolicyCRDFile = "grafana.integreatly.org_grafananotificationpolicies.yaml"
+	invalidGrafanaContinueRule       = "!has(self.continue)"
+	escapedGrafanaContinueRule       = "!has(self.__continue__)"
+)
+
+// patchGrafanaNotificationPolicyCRDs fixes a CEL rule emitted by the Grafana
+// Operator 5.21.4 CRD generator. "continue" is a CEL reserved keyword, so the
+// field must use Kubernetes' __{keyword}__ escaping in validation expressions.
+// Replacing the exact expression in the exact CRD keeps the workaround narrow;
+// a future chart containing the escaped rule passes through unchanged.
+// Upstream fix: https://github.com/grafana/grafana-operator/pull/2583
+func patchGrafanaNotificationPolicyCRDs(chrt helmchart.Charter) error {
+	accessor, err := helmchart.NewAccessor(chrt)
+	if err != nil {
+		return fmt.Errorf("access Helm chart: %w", err)
+	}
+
+	patchFiles := func(files []*common.File) {
+		for _, file := range files {
+			if filepath.Base(file.Name) != grafanaNotificationPolicyCRDFile {
+				continue
+			}
+			file.Data = bytes.ReplaceAll(
+				file.Data,
+				[]byte(invalidGrafanaContinueRule),
+				[]byte(escapedGrafanaContinueRule),
+			)
+		}
+	}
+
+	patchFiles(accessor.Files())
+	patchFiles(accessor.Templates())
+
+	for _, dependency := range accessor.Dependencies() {
+		if err := patchGrafanaNotificationPolicyCRDs(dependency); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/operator/grafana_crd_patch_test.go
+++ b/pkg/operator/grafana_crd_patch_test.go
@@ -1,0 +1,145 @@
+package operator
+
+import (
+	"bytes"
+	"testing"
+
+	"helm.sh/helm/v4/pkg/chart/common"
+	v2chart "helm.sh/helm/v4/pkg/chart/v2"
+)
+
+const brokenGrafanaNotificationPolicyCRD = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: grafananotificationpolicies.grafana.integreatly.org
+spec:
+  versions:
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          properties:
+            spec:
+              properties:
+                route:
+                  properties:
+                    active_time_intervals:
+                      type: array
+                    continue:
+                      type: boolean
+                    match_re:
+                      type: object
+                    matchers:
+                      type: array
+                    mute_time_intervals:
+                      type: array
+                    object_matchers:
+                      type: array
+                    receiver:
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: continue is invalid on the top level route node
+                      rule: '!has(self.continue)'
+                    - message: match_re is invalid on the top level route node
+                      rule: '!has(self.match_re)'
+                    - message: matchers is invalid on the top level route node
+                      rule: '!has(self.matchers)'
+                    - message: object_matchers is invalid on the top level route node
+                      rule: '!has(self.object_matchers)'
+                    - message: mute_time_intervals is invalid on the top level route node
+                      rule: '!has(self.mute_time_intervals)'
+                    - message: active_time_intervals is invalid on the top level route node
+                      rule: '!has(self.active_time_intervals)'
+                    - message: receiver must be present
+                      rule: 'has(self.receiver)'
+              type: object
+          type: object
+`
+
+func TestPatchGrafanaNotificationPolicyCRDs(t *testing.T) {
+	immutable := &common.File{
+		Name: "crds/" + grafanaNotificationPolicyCRDFile,
+		Data: []byte(brokenGrafanaNotificationPolicyCRD),
+	}
+	mutable := &common.File{
+		Name: "files/crds/" + grafanaNotificationPolicyCRDFile,
+		Data: []byte(brokenGrafanaNotificationPolicyCRD),
+	}
+
+	root := testChart("operator")
+	grafana := testChart("grafana-operator")
+	crds := testChart("crds")
+	grafana.Files = []*common.File{mutable}
+	crds.Files = []*common.File{immutable}
+	grafana.AddDependency(crds)
+	root.AddDependency(grafana)
+
+	if err := patchGrafanaNotificationPolicyCRDs(root); err != nil {
+		t.Fatalf("patchGrafanaNotificationPolicyCRDs() error = %v", err)
+	}
+
+	for _, file := range []*common.File{immutable, mutable} {
+		if bytes.Contains(file.Data, []byte(invalidGrafanaContinueRule)) {
+			t.Errorf("%s still contains invalid rule %q", file.Name, invalidGrafanaContinueRule)
+		}
+		if !bytes.Contains(file.Data, []byte(escapedGrafanaContinueRule)) {
+			t.Errorf("%s does not contain escaped rule %q", file.Name, escapedGrafanaContinueRule)
+		}
+		if !bytes.Contains(file.Data, []byte("has(self.receiver)")) {
+			t.Errorf("%s lost an unrelated valid rule", file.Name)
+		}
+		for _, rule := range []string{
+			"!has(self.match_re)",
+			"!has(self.matchers)",
+			"!has(self.object_matchers)",
+			"!has(self.mute_time_intervals)",
+			"!has(self.active_time_intervals)",
+		} {
+			if !bytes.Contains(file.Data, []byte(rule)) {
+				t.Errorf("%s lost valid rule %q", file.Name, rule)
+			}
+		}
+	}
+}
+
+func TestPatchGrafanaNotificationPolicyCRDLeavesFixedRuleUnchanged(t *testing.T) {
+	fixed := bytes.ReplaceAll(
+		[]byte(brokenGrafanaNotificationPolicyCRD),
+		[]byte(invalidGrafanaContinueRule),
+		[]byte(escapedGrafanaContinueRule),
+	)
+	file := &common.File{
+		Name: "crds/" + grafanaNotificationPolicyCRDFile,
+		Data: fixed,
+	}
+	root := testChart("operator")
+	root.Files = []*common.File{file}
+
+	if err := patchGrafanaNotificationPolicyCRDs(root); err != nil {
+		t.Fatalf("patchGrafanaNotificationPolicyCRDs() error = %v", err)
+	}
+	if !bytes.Equal(file.Data, fixed) {
+		t.Fatal("patchGrafanaNotificationPolicyCRDs() changed an already-fixed CRD")
+	}
+}
+
+func TestPatchGrafanaNotificationPolicyCRDsIgnoresOtherFiles(t *testing.T) {
+	root := testChart("operator")
+	original := []byte("rule: '!has(self.continue)'")
+	file := &common.File{
+		Name: "crds/another.yaml",
+		Data: append([]byte(nil), original...),
+	}
+	root.Files = []*common.File{file}
+
+	if err := patchGrafanaNotificationPolicyCRDs(root); err != nil {
+		t.Fatalf("patchGrafanaNotificationPolicyCRDs() error = %v", err)
+	}
+	if !bytes.Equal(file.Data, original) {
+		t.Fatal("patchGrafanaNotificationPolicyCRDs() changed an unrelated file")
+	}
+}
+
+func testChart(name string) *v2chart.Chart {
+	return &v2chart.Chart{Metadata: &v2chart.Metadata{Name: name}}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -760,6 +760,11 @@ func DeployOperator(
 		if err != nil {
 			return fmt.Errorf("failed to load chart: %w", err)
 		}
+		if telemetry.Mode == TelemetryModeFull {
+			if err := patchGrafanaNotificationPolicyCRDs(chartRequested); err != nil {
+				return fmt.Errorf("failed to patch operator chart telemetry CRDs: %w", err)
+			}
+		}
 
 		// Run the upgrade
 		_, err = upgradeClient.RunWithContext(ctx, releaseName, chartRequested, releaseValues)
@@ -784,6 +789,11 @@ func DeployOperator(
 		chartRequested, err := loader.Load(cp)
 		if err != nil {
 			return fmt.Errorf("failed to load chart: %w", err)
+		}
+		if telemetry.Mode == TelemetryModeFull {
+			if err := patchGrafanaNotificationPolicyCRDs(chartRequested); err != nil {
+				return fmt.Errorf("failed to patch operator chart telemetry CRDs: %w", err)
+			}
 		}
 
 		// Run the install


### PR DESCRIPTION
## What changed

- Patch the bundled GrafanaNotificationPolicy CRD before Helm install or upgrade when full telemetry is enabled.
- Rewrite the invalid CEL field access from `self.continue` to Kubernetes' reserved-keyword form, `self.__continue__`.
- Traverse nested Helm dependencies so both the mutable and immutable CRD copies are covered.
- Add regression tests for both copies, already-fixed charts, unrelated files, and preservation of the remaining validation rules.

## Root cause

Operator chart `2.0.0-beta.1` bundles Grafana Operator chart `5.21.4`. Its GrafanaNotificationPolicy CRD uses `continue`, a CEL reserved keyword, without Kubernetes' required escaping. Kubernetes versions before 1.32 reject the CRD while compiling the validation rule, causing full-telemetry deployment to fail before the W&B operator is installed.

This applies the same expression change as the [upstream Grafana Operator fix](https://github.com/grafana/grafana-operator/pull/2583). The workaround is narrowly scoped to the exact CRD filename and expression, so a future operator chart containing the upstream fix is left unchanged.

## Impact

Full telemetry installations from Watchtower/WSM can deploy to Kubernetes 1.30. Telemetry `off` and `forward` are unchanged.

## Validation

- `go test ./...`
- `golangci-lint run --timeout=5m --concurrency=4 --max-same-issues=20`
- Verified the patch against both affected CRD copies in the exact `operator-2.0.0-beta.1` archive downloaded by Watchtower.
