### PR TITLE
feat(operator): expose OpenShift mode via flag

### DIFF
--- a/cmd/wsm/deploy_v2.go
+++ b/cmd/wsm/deploy_v2.go
@@ -368,6 +368,7 @@ func operatorDeployCmd() *cobra.Command {
 	var gatewayCRDURL string
 	var skipGatewayCRDs bool
 	var allowUnsupportedArch bool
+	var openshift bool
 
 	cmd := &cobra.Command{
 		Use:   "operator",
@@ -444,6 +445,7 @@ func operatorDeployCmd() *cobra.Command {
 				gatewayCRDURL,
 				skipGatewayCRDs,
 				allowUnsupportedArch,
+				openshift,
 				crOverrides,
 			); err != nil {
 				fmt.Printf("\n✗ Operator install failed: %v\n", err)
@@ -484,6 +486,7 @@ func operatorDeployCmd() *cobra.Command {
 	cmd.Flags().StringVar(&gatewayCRDURL, "gateway-api-crd-url", "", "Fetch the Gateway API CRDs from this URL instead of the GitHub default (use a mirrored copy for air-gapped installs)")
 	cmd.Flags().BoolVar(&skipGatewayCRDs, "skip-gateway-api-crds", false, "Assume the Gateway API CRDs are already installed; fail instead of fetching them from the internet")
 	cmd.Flags().BoolVar(&allowUnsupportedArch, "allow-unsupported-arch", false, "Deploy even if the cluster has non-amd64 nodes. The wandb-operator image is published amd64-only and will crash under emulation on arm64 (e.g. Kind on Apple Silicon); set this only if you know your operator image is multi-arch.")
+	cmd.Flags().BoolVar(&openshift, "openshift", false, "Enable OpenShift compatibility for the operator and bundled managed-service pods")
 
 	// Chart-only telemetry knobs. These configure the operator's telemetry Helm release, so they
 	// belong to `operator` alone — `wandb deploy` only applies the CR and can't honor them.
@@ -566,6 +569,7 @@ func performDeploy(
 	gatewayCRDURL string,
 	skipGatewayCRDs bool,
 	allowUnsupportedArch bool,
+	openshift bool,
 	crOverrides []operator.CROverride,
 ) error {
 	ctx := context.Background()
@@ -692,7 +696,7 @@ func performDeploy(
 	fmt.Printf("[%d/%d] Deploying Required operators...", currentStep, totalSteps)
 	start := time.Now()
 
-	if err := operator.DeployOperator(ctx, operatorNamespace, operatorChartVersion, mirror, telemetry, wandbNamespace); err != nil {
+	if err := operator.DeployOperator(ctx, operatorNamespace, operatorChartVersion, mirror, telemetry, wandbNamespace, openshift); err != nil {
 		fmt.Println(" ✗")
 		return err
 	}

--- a/docs/deployment/on-prem.md
+++ b/docs/deployment/on-prem.md
@@ -267,6 +267,7 @@ Even with everything mirrored, a few things default to an online source. Each ha
 
 **Before / during the deploy**
 - **Gateway API CRDs** — carry in `standard-install.yaml` and `kubectl apply` it (then `--skip-gateway-api-crds`), or host it internally and use `--gateway-api-crd-url`.
+- **OpenShift** — pass `--openshift` so the managed-service operators are admitted under `restricted-v2`. This does **not** fix the frontend nginx pod (it rewrites root-owned files at startup, which an arbitrary UID can't write); that still requires BYO ingress / an upstream operator fix.
 - **Node container-runtime registry mirror** — how the managed DB images (ClickHouse/MySQL/Redis/SeaweedFS/Kafka) reach the mirror on **every** path (see the Phase 2 diagrams): each node mirrors `docker.io`/`quay.io`/`ghcr.io`/`us-docker.pkg.dev` → `$REG/<host-stripped>`. `wsm cluster create --insecure-registry-host $REG` sets this up for Kind; on a real cluster you configure `certs.d` per node. `--mirror-registry` does not retarget these (see the Tier-3 note above).
 - **Registry pull credentials** — for an auth'd registry, `docker login` + `helm registry login` for `wsm`, and create an `imagePullSecret` for the operator + W&B namespaces so in-cluster pulls and the manifest fetch authenticate.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -43,6 +43,7 @@ wsm deploy-v2 operator [flags]
 | `--gateway-api-crd-url` | — | Fetch the Gateway API CRDs from this URL instead of the GitHub default (use a mirrored copy for air-gapped installs). |
 | `--skip-gateway-api-crds` | `false` | Assume the Gateway API CRDs are already installed; fail instead of fetching them from the internet. |
 | `--allow-unsupported-arch` | `false` | Deploy even if the cluster has non-amd64 nodes. The wandb-operator image is amd64-only and crashes under emulation on arm64 (e.g. Kind on Apple Silicon); WSM fails fast on this by default. |
+| `--openshift` | `false` | Enable OpenShift compatibility for the operator and bundled managed-service pods (MySQL/moco, Redis, ClickHouse, SeaweedFS). The bundled frontend still can't run on OpenShift, so bring your own ingress — see [On-Prem Deployment](../deployment/on-prem.md). |
 | `--observability-forward-endpoint` | — | OTLP endpoint to forward telemetry to. **Required** when `--observability-mode=forward` |
 | `--observability-otel-secret` | — | Name of the OTEL connection secret (`telemetry.otel.secretName`). Chart default `wandb-otel-connection` if unset. Applied when mode is `full` or `forward` |
 | `--observability-otel-protocol` | — | OTEL exporter protocol, e.g. `http/protobuf` or `grpc` (`telemetry.otel.protocol`). Chart default if unset |

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -610,6 +610,49 @@ func installGatewayApiCRDs(ctx context.Context, crdURL string) error {
 	return nil
 }
 
+// mergeValues shallow-merges add into releaseValues[key], creating it if absent.
+func mergeValues(releaseValues map[string]interface{}, key string, add map[string]interface{}) {
+	existing, ok := releaseValues[key].(map[string]interface{})
+	if !ok {
+		existing = map[string]interface{}{}
+		releaseValues[key] = existing
+	}
+	for k, v := range add {
+		existing[k] = v
+	}
+}
+
+// applyOpenShiftValues mirrors the operator's profiles/openshift.yaml so the
+// operator and bundled managed-service pods deploy cleanly on OpenShift.
+func applyOpenShiftValues(releaseValues map[string]interface{}) {
+	nullSC := map[string]interface{}{
+		"runAsUser":           nil,
+		"runAsGroup":          nil,
+		"fsGroup":             nil,
+		"fsGroupChangePolicy": nil,
+	}
+	releaseValues["openshift"] = map[string]interface{}{"enabled": true}
+	mergeValues(releaseValues, "wandb-operator", map[string]interface{}{
+		"podSecurityContext": nullSC,
+		"containers": map[string]interface{}{
+			"operator": map[string]interface{}{
+				"env": map[string]interface{}{
+					"OPENSHIFT": map[string]interface{}{"value": "true"},
+				},
+			},
+		},
+	})
+	mergeValues(releaseValues, "redis-operator", map[string]interface{}{"podSecurityContext": nullSC})
+	mergeValues(releaseValues, "altinity-clickhouse-operator", map[string]interface{}{"podSecurityContext": nullSC})
+	mergeValues(releaseValues, "seaweedfs-operator", map[string]interface{}{"podSecurityContext": map[string]interface{}{
+		"runAsUser":  nil,
+		"runAsGroup": nil,
+		"fsGroup":    nil,
+	}})
+	mergeValues(releaseValues, "moco", map[string]interface{}{"extraArgs": []interface{}{"--disable-default-security-context"}})
+	mergeValues(releaseValues, "grafana-operator", map[string]interface{}{"isOpenShift": true})
+}
+
 // DeployOperator deploys the W&B operator chart version specified.  The chart is called operator and is available in oci://us-docker.pkg.dev/wandb-production/public/wandb/charts
 func DeployOperator(
 	ctx context.Context,
@@ -618,6 +661,7 @@ func DeployOperator(
 	mirror *MirrorConfig,
 	telemetry TelemetryConfig,
 	wandbNamespace string,
+	openshift bool,
 ) error {
 	const chartName = "operator"
 	const releaseName = "wandb-operator"
@@ -739,6 +783,10 @@ func DeployOperator(
 		releaseValues["grafana-operator"] = map[string]interface{}{"enabled": true}
 	case TelemetryModeForward:
 		releaseValues["victoria-metrics-operator"] = map[string]interface{}{"enabled": true}
+	}
+
+	if openshift {
+		applyOpenShiftValues(releaseValues)
 	}
 
 	if releaseExists {


### PR DESCRIPTION
# Summary of Changes

**Jira:** [ONPREM-XXXX](https://coreweave.atlassian.net/browse/ONPREM-XXXX)

Adds a `--openshift` flag to `wsm deploy-v2 operator` so the operator's OpenShift mode can be turned on at install time — previously unreachable through wsm.

- Threads a new `openshift bool` from the flag through `performDeploy` into `operator.DeployOperator`.
- `applyOpenShiftValues` reproduces the operator's `profiles/openshift.yaml`
- A `mergeValues` helper shallow-merges these onto any values already set for `--mirror-registry` / telemetry, so those blocks aren't clobbered in either direction.

# Test Plan

- `make build` — compiles clean
- `make lint` — go vet + golangci-lint clean (`0 issues`)
- `make fmt` — no diff
- `go mod tidy` — no diff
- `./wsm deploy-v2 operator --help` — flag present and parses

# Requirements

- [x] Lint clean (`make lint`)
- [x] Format clean (`make fmt` leaves no diff)
- [x] `go.mod` / `go.sum` tidy (`go mod tidy` leaves no diff)
- [x] I/AI have tested the changes on this PR
- [x] Docs (`docs/`, `docs/reference/commands.md`, `docs/reference/cr-fields.md`) / `CLAUDE.md` updated if behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `--openshift` option to operator deployments.
  * Configures the operator and bundled managed services for OpenShift’s `restricted-v2` security constraints, improving pod admission.

* **Documentation**
  * Updated deployment guidance and command reference with OpenShift usage details.
  * Clarified that frontend nginx write-permission issues require separate ingress configuration or an upstream fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->