### PR TITLE
feat(operator): add openshift-status command

### DIFF
--- a/cmd/wsm/deploy_v2.go
+++ b/cmd/wsm/deploy_v2.go
@@ -497,6 +497,37 @@ func operatorDeployCmd() *cobra.Command {
 	cmd.Flags().String("observability-otel-resource-attributes", "", "Additional OTEL resource attributes, comma-separated key=value (telemetry.otel.resourceAttributes; chart default if unset)")
 	cmd.Flags().String("observability-forward-protocol", "", "OTLP forwarding protocol, e.g. http/protobuf or grpc (telemetry.forwarding.otlp.protocol; only applied when --observability-mode=forward)")
 	cmd.Flags().StringToString("observability-forward-headers", nil, "OTLP forwarding headers as key=value pairs, e.g. Authorization=Bearer... (telemetry.forwarding.otlp.headers; only applied when --observability-mode=forward)")
+
+	cmd.AddCommand(operatorOpenShiftStatusCmd())
+	return cmd
+}
+
+func operatorOpenShiftStatusCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "openshift-status",
+		Short: "Report whether OpenShift mode is enabled on the installed operator",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			operatorNamespace, _ := cmd.Flags().GetString("operator-namespace")
+
+			cfg, err := operator.GetOperatorOpenShiftConfig(operatorNamespace)
+			if err != nil {
+				return err
+			}
+			if cfg == nil {
+				fmt.Printf("Operator is not installed in namespace %q.\n", operatorNamespace)
+				return nil
+			}
+
+			fmt.Printf("OpenShift mode: %v\n", cfg.Enabled)
+			fmt.Printf("  Operator OPENSHIFT env set: %v\n", cfg.OperatorEnvSet)
+			if len(cfg.AdjustedOperators) > 0 {
+				fmt.Printf("  Adjusted operators: %s\n", strings.Join(cfg.AdjustedOperators, ", "))
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().String("operator-namespace", "wandb-operators", "Namespace where the operator is installed")
 	return cmd
 }
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -69,6 +69,32 @@ wsm deploy-v2 operator --context kind-wandb \
 # Air-gapped: pull every chart and image from a mirror registry
 # (populate it first with `wsm registry mirror --to harbor.corp:5443`)
 wsm deploy-v2 operator --context prod --mirror-registry harbor.corp:5443
+
+# Deploy the operator configured for OpenShift's restricted-v2 SCC
+wsm deploy-v2 operator --context ocp --openshift
+```
+
+---
+
+### `wsm deploy-v2 operator openshift-status`
+
+Reports whether the installed operator was deployed with `--openshift`. OpenShift mode isn't reconciled from the CR, so re-running `operator` without `--openshift` silently reverts it — use this to check the current state before an upgrade.
+
+#### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--context` | — | **Required.** Name of the kubeconfig context to use |
+| `--operator-namespace` | `wandb-operators` | Namespace where the operator is installed |
+
+#### Examples
+
+```bash
+# Check whether OpenShift mode is enabled on the installed operator
+wsm deploy-v2 operator openshift-status --context ocp
+
+# Point at a non-default operator namespace
+wsm deploy-v2 operator openshift-status --context ocp --operator-namespace wandb-operators
 ```
 
 ---

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -653,6 +653,111 @@ func applyOpenShiftValues(releaseValues map[string]interface{}) {
 	mergeValues(releaseValues, "grafana-operator", map[string]interface{}{"isOpenShift": true})
 }
 
+// OpenShiftConfig reports how OpenShift mode is configured on the operator release.
+type OpenShiftConfig struct {
+	Enabled           bool     // openshift.enabled on the operator release
+	OperatorEnvSet    bool     // OPENSHIFT=true env on the operator container
+	AdjustedOperators []string // managed-service operators whose fixed IDs were nulled
+}
+
+// GetOperatorOpenShiftConfig reads the installed operator release and reports its
+// OpenShift settings. Returns nil when the operator is not installed in namespace.
+func GetOperatorOpenShiftConfig(namespace string) (*OpenShiftConfig, error) {
+	const releaseName = "wandb-operator"
+
+	settings := cli.New()
+	settings.SetNamespace(namespace)
+	settings.KubeContext = kubectl.GetContext()
+
+	actionConfig, err := initActionConfig(settings)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize action config: %w", err)
+	}
+
+	exists, err := checkReleaseExists(actionConfig, releaseName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check operator release: %w", err)
+	}
+	if !exists {
+		return nil, nil
+	}
+
+	rel, err := action.NewGet(actionConfig).Run(releaseName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read operator release %q: %w", releaseName, err)
+	}
+	release, ok := rel.(*v1.Release)
+	if !ok {
+		return nil, fmt.Errorf("unexpected release type for %q", releaseName)
+	}
+
+	return openShiftConfigFromValues(release.Config), nil
+}
+
+// openShiftConfigFromValues mirrors applyOpenShiftValues in reverse: it inspects the
+// operator release values for the OpenShift settings that flag writes.
+func openShiftConfigFromValues(values map[string]interface{}) *OpenShiftConfig {
+	cfg := &OpenShiftConfig{}
+	if v, ok := nestedValue(values, "openshift", "enabled"); ok {
+		cfg.Enabled, _ = v.(bool)
+	}
+	if v, ok := nestedValue(values, "wandb-operator", "containers", "operator", "env", "OPENSHIFT", "value"); ok {
+		s, _ := v.(string)
+		cfg.OperatorEnvSet = s == "true"
+	}
+	scFields := []string{"runAsUser", "runAsGroup", "fsGroup", "fsGroupChangePolicy"}
+	adjustments := []struct {
+		name   string
+		fields []string
+	}{
+		{"wandb-operator", scFields},
+		{"redis-operator", scFields},
+		{"altinity-clickhouse-operator", scFields},
+		{"seaweedfs-operator", []string{"runAsUser", "runAsGroup", "fsGroup"}},
+	}
+	for _, adj := range adjustments {
+		if podSecurityContextNulled(values, adj.name, adj.fields) {
+			cfg.AdjustedOperators = append(cfg.AdjustedOperators, adj.name)
+		}
+	}
+	if v, ok := nestedValue(values, "moco", "extraArgs"); ok {
+		if args, ok := v.([]interface{}); ok {
+			for _, a := range args {
+				if s, _ := a.(string); s == "--disable-default-security-context" {
+					cfg.AdjustedOperators = append(cfg.AdjustedOperators, "moco")
+				}
+			}
+		}
+	}
+	return cfg
+}
+
+// podSecurityContextNulled reports whether every named field under the operator's
+// podSecurityContext exists and is nil — the signature applyOpenShiftValues writes.
+func podSecurityContextNulled(values map[string]interface{}, operator string, fields []string) bool {
+	for _, f := range fields {
+		if v, ok := nestedValue(values, operator, "podSecurityContext", f); !ok || v != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// nestedValue walks a chain of string keys through nested value maps.
+func nestedValue(values map[string]interface{}, keys ...string) (interface{}, bool) {
+	var cur interface{} = values
+	for _, k := range keys {
+		m, ok := cur.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		if cur, ok = m[k]; !ok {
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
 // DeployOperator deploys the W&B operator chart version specified.  The chart is called operator and is available in oci://us-docker.pkg.dev/wandb-production/public/wandb/charts
 func DeployOperator(
 	ctx context.Context,


### PR DESCRIPTION
# Summary of Changes

**Jira:** [ONPREM-XXXX](https://coreweave.atlassian.net/browse/ONPREM-XXXX)

Follow-on to #97. That PR added `--openshift` to enable OpenShift mode on the operator install, but left no way to *observe* the resulting state — and because the setting isn't reconciled from the CR, re-running `operator` without the flag silently reverts it. This adds the read side so the current state is knowable before an upgrade.

- `operator.GetOperatorOpenShiftConfig(namespace)` reads the installed operator Helm release's values and returns an `OpenShiftConfig` (whether `openshift.enabled` is set, whether the `OPENSHIFT` env is on the operator, and which bundled operators had their fixed IDs nulled). Returns nil when the operator isn't installed.
- New `wsm deploy-v2 operator openshift-status` command prints that state; takes `--operator-namespace` (default `wandb-operators`).
- Docs: new command section + examples in `docs/reference/commands.md`, plus an `--openshift` deploy example.

# Test Plan

- `make build` — compiles clean
- `make lint` — go vet + golangci-lint clean (`0 issues`)
- `make fmt` — no diff
- `go mod tidy` — no diff
- **Live read (Kind):** `openshift-status` against the real installed operator → `OpenShift mode: false` (correct — installed without `--openshift`); bogus namespace → "Operator is not installed."
- **Round-trip (unit, run then removed):** values written by `applyOpenShiftValues` read back as fully enabled (all six operators); empty values read back disabled.
- **Not run:** live *write-then-read* on a real cluster — the only Kind cluster here is arm64 and the operator image is amd64-only, so `--openshift` can't be applied to flip the status to `true` on this machine. Needs an amd64/OpenShift cluster.

# Requirements

- [x] Lint clean (`make lint`)
- [x] Format clean (`make fmt` leaves no diff)
- [x] `go.mod` / `go.sum` tidy (`go mod tidy` leaves no diff)
- [x] I/AI have tested the changes on this PR
- [x] Docs (`docs/`, `docs/reference/commands.md`, `docs/reference/cr-fields.md`) / `CLAUDE.md` updated if behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `wsm deploy-v2 operator openshift-status` to report whether the installed operator is configured for OpenShift mode.
  * Displays the OpenShift environment setting and any adjusted operators.
  * Supports custom contexts and operator namespaces.

* **Documentation**
  * Added command usage, flags, examples, and notes about OpenShift configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->