### PR TITLE
feat(deploy-v2): add operator destroy command

### DIFF
--- a/cmd/wsm/deploy_v2.go
+++ b/cmd/wsm/deploy_v2.go
@@ -499,6 +499,78 @@ func operatorDeployCmd() *cobra.Command {
 	cmd.Flags().StringToString("observability-forward-headers", nil, "OTLP forwarding headers as key=value pairs, e.g. Authorization=Bearer... (telemetry.forwarding.otlp.headers; only applied when --observability-mode=forward)")
 
 	cmd.AddCommand(operatorOpenShiftStatusCmd())
+	cmd.AddCommand(operatorDestroyCmd())
+	return cmd
+}
+
+// operatorDestroyCmd uninstalls the operator; the --include-* flags opt into removing
+// the shared cert-manager and nginx-gateway releases too.
+func operatorDestroyCmd() *cobra.Command {
+	var includeCertManager bool
+	var includeNginxGateway bool
+
+	cmd := &cobra.Command{
+		Use:   "destroy",
+		Short: "Uninstall the v2 operator (optionally cert-manager and nginx-gateway too)",
+		Long:  `Uninstall the wandb-operator Helm release. cert-manager and nginx-gateway are shared infrastructure and are left in place unless --include-cert-manager / --include-nginx-gateway are set. Use 'wsm cluster cleanup' to remove everything wsm deployed, including W&B CRs.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			operatorNamespace, _ := cmd.Flags().GetString("operator-namespace")
+			ctx := context.Background()
+
+			fmt.Printf("→ Deleting W&B operator in namespace '%s'...\n", operatorNamespace)
+			removed, err := operator.DeleteOperator(ctx, operatorNamespace)
+			if err != nil {
+				return err
+			}
+			if err := kubectl.DeleteDeploymentMarker(ctx, operatorNamespace, "operator"); err != nil {
+				fmt.Printf("  ✗ Failed to remove operator marker in %s: %v\n", operatorNamespace, err)
+			}
+			if removed {
+				fmt.Println("✓ Operator uninstalled")
+			} else {
+				fmt.Printf("! No W&B operator found in namespace '%s'; nothing to uninstall\n", operatorNamespace)
+			}
+
+			// All markers live in the operator namespace's ConfigMap.
+			if includeCertManager {
+				fmt.Println("→ Deleting cert-manager...")
+				cmRemoved, err := operator.DeleteCertManager(ctx)
+				if err != nil {
+					return err
+				}
+				if err := kubectl.DeleteDeploymentMarker(ctx, operatorNamespace, "cert-manager"); err != nil {
+					return fmt.Errorf("failed to remove cert-manager marker in %s: %w", operatorNamespace, err)
+				}
+				if cmRemoved {
+					fmt.Println("✓ cert-manager uninstalled")
+				} else {
+					fmt.Println("! No cert-manager release found; nothing to uninstall")
+				}
+			}
+
+			if includeNginxGateway {
+				fmt.Println("→ Deleting nginx-gateway...")
+				ngRemoved, err := operator.DeleteNginxGateway(ctx)
+				if err != nil {
+					return err
+				}
+				if err := kubectl.DeleteDeploymentMarker(ctx, operatorNamespace, "nginx-gateway"); err != nil {
+					return fmt.Errorf("failed to remove nginx-gateway marker in %s: %w", operatorNamespace, err)
+				}
+				if ngRemoved {
+					fmt.Println("✓ nginx-gateway uninstalled")
+				} else {
+					fmt.Println("! No nginx-gateway release found; nothing to uninstall")
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().String("operator-namespace", "wandb-operators", "Namespace where the operator is installed")
+	cmd.Flags().BoolVar(&includeCertManager, "include-cert-manager", false, "Also uninstall the cert-manager Helm release")
+	cmd.Flags().BoolVar(&includeNginxGateway, "include-nginx-gateway", false, "Also uninstall the nginx-gateway-fabric Helm release")
 	return cmd
 }
 
@@ -1737,7 +1809,7 @@ func performCleanup() error {
 
 	for _, ns := range operatorNamespaces {
 		fmt.Printf("→ Deleting W&B operator in namespace '%s'...\n", ns)
-		if err := operator.DeleteOperator(ctx, ns); err != nil {
+		if _, err := operator.DeleteOperator(ctx, ns); err != nil {
 			fmt.Printf("  ✗ Failed to delete operator in %s: %v\n", ns, err)
 			return err
 		}
@@ -1751,7 +1823,7 @@ func performCleanup() error {
 
 	// 3. Delete cert-manager
 	fmt.Println("→ Deleting cert-manager...")
-	if err := operator.DeleteCertManager(ctx); err != nil {
+	if _, err := operator.DeleteCertManager(ctx); err != nil {
 		fmt.Printf("  ✗ Failed to delete cert-manager: %v\n", err)
 	}
 
@@ -1766,7 +1838,7 @@ func performCleanup() error {
 
 	// 4. Delete nginx-gateway
 	fmt.Println("→ Deleting nginx-gateway...")
-	if err := operator.DeleteNginxGateway(ctx); err != nil {
+	if _, err := operator.DeleteNginxGateway(ctx); err != nil {
 		fmt.Printf("  ✗ Failed to delete nginx-gateway: %v\n", err)
 	}
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -99,6 +99,35 @@ wsm deploy-v2 operator openshift-status --context ocp --operator-namespace wandb
 
 ---
 
+### `wsm deploy-v2 operator destroy`
+
+Uninstalls the `wandb-operator` Helm release. cert-manager and nginx-gateway are shared infrastructure and are left in place by default; opt into removing them with `--include-cert-manager` / `--include-nginx-gateway`. To remove everything `wsm` deployed (operator, cert-manager, nginx-gateway, **and** any W&B CRs) in one shot, use [`wsm cluster cleanup`](#wsm-cluster) instead. This command does not delete the W&B instance; destroy it first with [`wsm deploy-v2 wandb destroy`](#wsm-deploy-v2-wandb-destroy).
+
+#### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--context` | — | **Required.** Name of the kubeconfig context to use |
+| `--operator-namespace` | `wandb-operators` | Namespace where the operator is installed |
+| `--include-cert-manager` | `false` | Also uninstall the cert-manager Helm release (shared infra — only if nothing else in the cluster relies on it) |
+| `--include-nginx-gateway` | `false` | Also uninstall the nginx-gateway-fabric Helm release (shared infra) |
+
+#### Examples
+
+```bash
+# Uninstall the operator only, keeping cert-manager and nginx-gateway
+wsm deploy-v2 operator destroy --context prod
+
+# Point at a non-default operator namespace
+wsm deploy-v2 operator destroy --context prod --operator-namespace wandb-operators
+
+# Also tear down the shared infra wsm installed (operator + cert-manager + nginx-gateway)
+wsm deploy-v2 operator destroy --context prod \
+  --include-cert-manager --include-nginx-gateway
+```
+
+---
+
 ### `wsm deploy-v2 wandb deploy`
 
 Deploys a W&B instance (WeightsAndBiases CR).

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -276,14 +276,16 @@ func certManagerDeploymentExists(ctx context.Context) (bool, error) {
 }
 
 // DeleteCertManager deletes the cert-manager resources
-func DeleteCertManager(ctx context.Context) error {
+// DeleteCertManager uninstalls the cert-manager Helm release. removed is false when
+// there was no release to uninstall.
+func DeleteCertManager(ctx context.Context) (removed bool, err error) {
 	settings := cli.New()
 	settings.SetNamespace(certManagerNamespace)
 	settings.KubeContext = kubectl.GetContext()
 
 	actionConfig, err := initActionConfig(settings)
 	if err != nil {
-		return fmt.Errorf("failed to initialize action config: %w", err)
+		return false, fmt.Errorf("failed to initialize action config: %w", err)
 	}
 
 	uninstallClient := action.NewUninstall(actionConfig)
@@ -293,12 +295,12 @@ func DeleteCertManager(ctx context.Context) error {
 	_, err = uninstallClient.Run(certManagerReleaseName)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			return nil
+			return false, nil
 		}
-		return fmt.Errorf("failed to uninstall cert-manager: %w", err)
+		return false, fmt.Errorf("failed to uninstall cert-manager: %w", err)
 	}
 
-	return nil
+	return true, nil
 }
 
 // InstallNginxGateway installs nginx-gateway-fabric.
@@ -488,15 +490,16 @@ func nginxGatewayDeploymentExists(ctx context.Context) (bool, error) {
 	return false, fmt.Errorf("failed to check nginx-gateway deployment %q: %w", nginxGatewayDeploymentName, err)
 }
 
-// DeleteNginxGateway deletes the nginx-gateway-fabric resources
-func DeleteNginxGateway(ctx context.Context) error {
+// DeleteNginxGateway uninstalls the nginx-gateway-fabric Helm release. removed is false
+// when there was no release to uninstall.
+func DeleteNginxGateway(ctx context.Context) (removed bool, err error) {
 	settings := cli.New()
 	settings.SetNamespace(nginxGatewayNamespace)
 	settings.KubeContext = kubectl.GetContext()
 
 	actionConfig, err := initActionConfig(settings)
 	if err != nil {
-		return fmt.Errorf("failed to initialize action config: %w", err)
+		return false, fmt.Errorf("failed to initialize action config: %w", err)
 	}
 
 	uninstallClient := action.NewUninstall(actionConfig)
@@ -506,12 +509,12 @@ func DeleteNginxGateway(ctx context.Context) error {
 	_, err = uninstallClient.Run(nginxGatewayReleaseName)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			return nil
+			return false, nil
 		}
-		return fmt.Errorf("failed to uninstall nginx-gateway: %w", err)
+		return false, fmt.Errorf("failed to uninstall nginx-gateway: %w", err)
 	}
 
-	return nil
+	return true, nil
 }
 
 // gatewayApiCRDsExist checks if Gateway API CRDs exist in the cluster
@@ -1023,8 +1026,9 @@ func WaitForOperator(ctx context.Context, namespace string, timeout time.Duratio
 	return nil
 }
 
-// DeleteOperator uninstalls the W&B operator Helm release
-func DeleteOperator(ctx context.Context, namespace string) error {
+// DeleteOperator uninstalls the W&B operator Helm release. removed is false when there
+// was no release to uninstall.
+func DeleteOperator(ctx context.Context, namespace string) (removed bool, err error) {
 	const releaseName = "wandb-operator"
 
 	settings := cli.New()
@@ -1033,7 +1037,7 @@ func DeleteOperator(ctx context.Context, namespace string) error {
 
 	actionConfig, err := initActionConfig(settings)
 	if err != nil {
-		return fmt.Errorf("failed to initialize action config: %w", err)
+		return false, fmt.Errorf("failed to initialize action config: %w", err)
 	}
 
 	uninstallClient := action.NewUninstall(actionConfig)
@@ -1043,12 +1047,12 @@ func DeleteOperator(ctx context.Context, namespace string) error {
 	_, err = uninstallClient.Run(releaseName)
 	if err != nil {
 		if strings.Contains(err.Error(), "not found") {
-			return nil
+			return false, nil
 		}
-		return fmt.Errorf("failed to uninstall operator: %w", err)
+		return false, fmt.Errorf("failed to uninstall operator: %w", err)
 	}
 
-	return nil
+	return true, nil
 }
 
 // checkReleaseExists checks if a Helm release exists


### PR DESCRIPTION
# Summary of Changes

**Jira:** [ONPREM-XXXX](https://coreweave.atlassian.net/browse/ONPREM-XXXX)

Adds `wsm deploy-v2 operator destroy` to roll back an operator install — the missing counterpart to `wsm deploy-v2 wandb destroy`. Previously the only way to remove the operator was `wsm cluster cleanup`, which tears down the whole stack.

- **Operator-only by default.** Uninstalls the `wandb-operator` Helm release and removes its deployment marker; cert-manager and nginx-gateway (shared infra, possibly reused by other workloads) are left in place.
- **Opt-in shared-infra teardown.** `--include-cert-manager` and `--include-nginx-gateway` additionally uninstall those releases and drop their markers, reusing the existing `DeleteCertManager` / `DeleteNginxGateway`.
- **Honest messaging.** `DeleteOperator` / `DeleteCertManager` / `DeleteNginxGateway` now return `(removed bool, error)` so the command prints `✓ … uninstalled` on a real uninstall vs `! nothing to uninstall` on a no-op (idempotent, swallows "release not found"). The `performCleanup` call sites are updated accordingly.
- Marker edits are surgical: removing one component leaves the others in the shared `wsm-deployment-marker` ConfigMap intact, so a later `cluster cleanup` still works.

# Test Plan

- `make build` — compiles clean
- `make lint` — go vet + golangci-lint, 0 issues
- `make fmt` — no diff
- `go mod tidy` — no diff
- Kind smoke test (v2) against a local cluster:
  - operator-only destroy → operator release + marker gone, cert-manager/nginx-gateway and the W&B CR untouched, operator webhook configs cleaned up
  - `--include-cert-manager --include-nginx-gateway` → all three releases removed, marker ConfigMap deleted when emptied
  - idempotency → second run reports `! nothing to uninstall` for each component, exit 0
  - negatives → missing `--context` and bad context both error with exit 1; empty namespace is a clean no-op
  - destroy → redeploy cycle restores a running operator

Note: no unit-test suite exists in this repo; the above are the actual commands/steps run.

# Requirements

- [x] Lint clean (`make lint`)
- [x] Format clean (`make fmt` leaves no diff)
- [x] `go.mod` / `go.sum` tidy (`go mod tidy` leaves no diff)
- [x] I/AI have tested the changes on this PR
- [x] Docs (`docs/`, `docs/reference/commands.md`, `docs/reference/cr-fields.md`) / `CLAUDE.md` updated if behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `wsm deploy-v2 operator destroy` to uninstall the v2 operator.
  * Added options to also remove shared cert-manager and nginx-gateway components.
  * Deployment markers are removed when their associated releases are uninstalled.

* **Documentation**
  * Documented the new destroy command, available flags, and example usage.

* **Bug Fixes**
  * Improved cleanup handling when releases are already absent or cannot be initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->