### PR TITLE
feat(deploy-v2): add --enable-*-operator flags for bundled operators

### DIFF
--- a/cmd/wsm/deploy_v2.go
+++ b/cmd/wsm/deploy_v2.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -369,6 +370,10 @@ func operatorDeployCmd() *cobra.Command {
 	var skipGatewayCRDs bool
 	var allowUnsupportedArch bool
 	var openshift bool
+	var enableMocoOperator bool
+	var enableRedisOperator bool
+	var enableSeaweedfsOperator bool
+	var enableClickhouseOperator bool
 
 	cmd := &cobra.Command{
 		Use:   "operator",
@@ -419,6 +424,24 @@ func operatorDeployCmd() *cobra.Command {
 				return err
 			}
 
+			// Resolve which bundled operator subcharts stay enabled. An explicit
+			// --enable-* flag on this run wins; otherwise honor the choice persisted
+			// in the deployment marker so a flag-less upgrade preserves it.
+			savedDisabled, err := kubectl.LoadDisabledSubcharts(context.Background(), operatorNamespace)
+			if err != nil {
+				return err
+			}
+			resolveEnabled := func(flag, subchartKey string, flagValue bool) bool {
+				if cmd.Flags().Changed(flag) {
+					return flagValue
+				}
+				return !slices.Contains(savedDisabled, subchartKey)
+			}
+			wantMocoOperator := resolveEnabled("enable-moco-operator", "moco", enableMocoOperator)
+			wantRedisOperator := resolveEnabled("enable-redis-operator", "redis-operator", enableRedisOperator)
+			wantSeaweedfsOperator := resolveEnabled("enable-seaweedfs-operator", "seaweedfs-operator", enableSeaweedfsOperator)
+			wantClickhouseOperator := resolveEnabled("enable-clickhouse-operator", "altinity-clickhouse-operator", enableClickhouseOperator)
+
 			// Perform the deployment
 			deployStart := time.Now()
 			if err := performDeploy(
@@ -447,6 +470,10 @@ func operatorDeployCmd() *cobra.Command {
 				allowUnsupportedArch,
 				openshift,
 				crOverrides,
+				wantMocoOperator,
+				wantRedisOperator,
+				wantSeaweedfsOperator,
+				wantClickhouseOperator,
 			); err != nil {
 				fmt.Printf("\n✗ Operator install failed: %v\n", err)
 				return err
@@ -487,6 +514,10 @@ func operatorDeployCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&skipGatewayCRDs, "skip-gateway-api-crds", false, "Assume the Gateway API CRDs are already installed; fail instead of fetching them from the internet")
 	cmd.Flags().BoolVar(&allowUnsupportedArch, "allow-unsupported-arch", false, "Deploy even if the cluster has non-amd64 nodes. The wandb-operator image is published amd64-only and will crash under emulation on arm64 (e.g. Kind on Apple Silicon); set this only if you know your operator image is multi-arch.")
 	cmd.Flags().BoolVar(&openshift, "openshift", false, "Enable OpenShift compatibility for the operator and bundled managed-service pods")
+	cmd.Flags().BoolVar(&enableMocoOperator, "enable-moco-operator", true, "Enable the MOCO MySQL operator subchart within the wandb-operator Helm release. Set to false if you are bringing your own MySQL.")
+	cmd.Flags().BoolVar(&enableRedisOperator, "enable-redis-operator", true, "Enable the Redis operator subchart within the wandb-operator Helm release. Set to false if you are bringing your own Redis.")
+	cmd.Flags().BoolVar(&enableSeaweedfsOperator, "enable-seaweedfs-operator", true, "Enable the SeaweedFS operator subchart within the wandb-operator Helm release. Set to false if you are bringing your own object store. Also disables the prometheus-operator-crds subchart, which shares the same condition.")
+	cmd.Flags().BoolVar(&enableClickhouseOperator, "enable-clickhouse-operator", true, "Enable the Altinity ClickHouse operator subchart within the wandb-operator Helm release. Set to false if you are bringing your own ClickHouse.")
 
 	// Chart-only telemetry knobs. These configure the operator's telemetry Helm release, so they
 	// belong to `operator` alone — `wandb deploy` only applies the CR and can't honor them.
@@ -524,6 +555,11 @@ func operatorDestroyCmd() *cobra.Command {
 			}
 			if err := kubectl.DeleteDeploymentMarker(ctx, operatorNamespace, "operator"); err != nil {
 				fmt.Printf("  ✗ Failed to remove operator marker in %s: %v\n", operatorNamespace, err)
+			}
+			// Clear any persisted subchart-disable state so a future reinstall starts
+			// fresh (no-op if the marker ConfigMap was already removed above).
+			if err := kubectl.SaveDisabledSubcharts(ctx, operatorNamespace, nil); err != nil {
+				fmt.Printf("  ✗ Failed to clear disabled-subcharts state in %s: %v\n", operatorNamespace, err)
 			}
 			if removed {
 				fmt.Println("✓ Operator uninstalled")
@@ -674,6 +710,10 @@ func performDeploy(
 	allowUnsupportedArch bool,
 	openshift bool,
 	crOverrides []operator.CROverride,
+	enableMocoOperator bool,
+	enableRedisOperator bool,
+	enableSeaweedfsOperator bool,
+	enableClickhouseOperator bool,
 ) error {
 	ctx := context.Background()
 	installNginxGatewayMode = strings.ToLower(strings.TrimSpace(installNginxGatewayMode))
@@ -796,10 +836,19 @@ func performDeploy(
 	}
 
 	// Step 4: Deploy W&B operator
-	fmt.Printf("[%d/%d] Deploying Required operators...", currentStep, totalSteps)
+	subchartState := func(enabled bool) string {
+		if enabled {
+			return "✓"
+		}
+		return "✗"
+	}
+	fmt.Printf("[%d/%d] Deploying wandb-operator (moco-operator %s, redis-operator %s, seaweedfs-operator %s, clickhouse-operator %s)...",
+		currentStep, totalSteps,
+		subchartState(enableMocoOperator), subchartState(enableRedisOperator),
+		subchartState(enableSeaweedfsOperator), subchartState(enableClickhouseOperator))
 	start := time.Now()
 
-	if err := operator.DeployOperator(ctx, operatorNamespace, operatorChartVersion, mirror, telemetry, wandbNamespace, openshift); err != nil {
+	if err := operator.DeployOperator(ctx, operatorNamespace, operatorChartVersion, mirror, telemetry, wandbNamespace, openshift, enableMocoOperator, enableRedisOperator, enableSeaweedfsOperator, enableClickhouseOperator); err != nil {
 		fmt.Println(" ✗")
 		return err
 	}
@@ -824,6 +873,27 @@ func performDeploy(
 		markers += ",nginx-gateway"
 	}
 	if err := kubectl.CreateDeploymentMarker(ctx, "", operatorNamespace, markers); err != nil {
+		fmt.Println(" ✗")
+		return err
+	}
+
+	// Persist which subcharts were disabled so a later flag-less upgrade keeps them
+	// off. Written after the marker ConfigMap exists (created just above).
+	var disabledSubcharts []string
+	for _, s := range []struct {
+		enabled bool
+		key     string
+	}{
+		{enableMocoOperator, "moco"},
+		{enableRedisOperator, "redis-operator"},
+		{enableSeaweedfsOperator, "seaweedfs-operator"},
+		{enableClickhouseOperator, "altinity-clickhouse-operator"},
+	} {
+		if !s.enabled {
+			disabledSubcharts = append(disabledSubcharts, s.key)
+		}
+	}
+	if err := kubectl.SaveDisabledSubcharts(ctx, operatorNamespace, disabledSubcharts); err != nil {
 		fmt.Println(" ✗")
 		return err
 	}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -43,7 +43,11 @@ wsm deploy-v2 operator [flags]
 | `--gateway-api-crd-url` | — | Fetch the Gateway API CRDs from this URL instead of the GitHub default (use a mirrored copy for air-gapped installs). |
 | `--skip-gateway-api-crds` | `false` | Assume the Gateway API CRDs are already installed; fail instead of fetching them from the internet. |
 | `--allow-unsupported-arch` | `false` | Deploy even if the cluster has non-amd64 nodes. The wandb-operator image is amd64-only and crashes under emulation on arm64 (e.g. Kind on Apple Silicon); WSM fails fast on this by default. |
-| `--openshift` | `false` | Enable OpenShift compatibility for the operator and bundled managed-service pods (MySQL/moco, Redis, ClickHouse, SeaweedFS). The bundled frontend still can't run on OpenShift, so bring your own ingress — see [On-Prem Deployment](../deployment/on-prem.md). |
+| `--openshift` | `false` | Enable OpenShift compatibility for the operator and bundled managed-service pods (MySQL/MOCO, Redis, ClickHouse, SeaweedFS). The bundled frontend still can't run on OpenShift, so bring your own ingress — see [On-Prem Deployment](../deployment/on-prem.md). |
+| `--enable-moco-operator` | `true` | Install the bundled MOCO MySQL operator subchart. Set `false` to bring your own MySQL. |
+| `--enable-redis-operator` | `true` | Install the bundled Redis operator subchart. Set `false` to bring your own Redis. |
+| `--enable-seaweedfs-operator` | `true` | Install the bundled SeaweedFS (object store) operator subchart. Set `false` to bring your own object store. Also disables the `prometheus-operator-crds` subchart, which shares the same condition. |
+| `--enable-clickhouse-operator` | `true` | Install the bundled Altinity ClickHouse operator subchart. Set `false` to bring your own ClickHouse. |
 | `--observability-forward-endpoint` | — | OTLP endpoint to forward telemetry to. **Required** when `--observability-mode=forward` |
 | `--observability-otel-secret` | — | Name of the OTEL connection secret (`telemetry.otel.secretName`). Chart default `wandb-otel-connection` if unset. Applied when mode is `full` or `forward` |
 | `--observability-otel-protocol` | — | OTEL exporter protocol, e.g. `http/protobuf` or `grpc` (`telemetry.otel.protocol`). Chart default if unset |
@@ -72,7 +76,17 @@ wsm deploy-v2 operator --context prod --mirror-registry harbor.corp:5443
 
 # Deploy the operator configured for OpenShift's restricted-v2 SCC
 wsm deploy-v2 operator --context ocp --openshift
+
+# Bring your own MySQL and object store: skip the bundled MOCO / SeaweedFS operators
+wsm deploy-v2 operator --context my-cluster \
+  --enable-moco-operator=false \
+  --enable-seaweedfs-operator=false
 ```
+
+> **Subchart choices persist.** The `--enable-*-operator` flags are remembered in
+> the `wsm-deployment-marker` ConfigMap, so a later flag-less `wsm deploy-v2 operator`
+> upgrade keeps a previously disabled subchart disabled. Pass the flag again with
+> `=true` to re-enable it. `wsm deploy-v2 operator destroy` clears the saved state.
 
 ---
 

--- a/pkg/kubectl/markers.go
+++ b/pkg/kubectl/markers.go
@@ -95,6 +95,65 @@ func DeleteDeploymentMarker(ctx context.Context, namespace string, component str
 	return nil
 }
 
+// LoadDisabledSubcharts returns the operator subcharts previously disabled via the
+// --enable-* flags, read from the "disabled-subcharts" key of the deployment marker
+// ConfigMap. Returns an empty slice when the marker or the key is absent, so a
+// first install (no marker yet) sees nothing disabled.
+func LoadDisabledSubcharts(ctx context.Context, namespace string) ([]string, error) {
+	cm, err := GetConfigMap(ctx, "wsm-deployment-marker", namespace)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read deployment marker: %w", err)
+	}
+
+	raw, ok := cm.Data["disabled-subcharts"]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+
+	var disabled []string
+	for c := range strings.SplitSeq(raw, ",") {
+		if c = strings.TrimSpace(c); c != "" {
+			disabled = append(disabled, c)
+		}
+	}
+	return disabled, nil
+}
+
+// SaveDisabledSubcharts persists the disabled subchart list into the "disabled-subcharts"
+// key of the deployment marker ConfigMap, preserving the marker's other data. An empty
+// list removes the key. The marker ConfigMap is expected to already exist (created by
+// CreateDeploymentMarker); if it does not and there is nothing to persist, this is a no-op
+// (e.g. clearing state during destroy when the marker is already gone).
+func SaveDisabledSubcharts(ctx context.Context, namespace string, disabled []string) error {
+	cm, err := GetConfigMap(ctx, "wsm-deployment-marker", namespace)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			if len(disabled) == 0 {
+				return nil
+			}
+			return fmt.Errorf("cannot save disabled subcharts: deployment marker not found in namespace %q", namespace)
+		}
+		return fmt.Errorf("failed to read deployment marker: %w", err)
+	}
+
+	if cm.Data == nil {
+		cm.Data = map[string]string{}
+	}
+	if len(disabled) == 0 {
+		delete(cm.Data, "disabled-subcharts")
+	} else {
+		cm.Data["disabled-subcharts"] = strings.Join(disabled, ",")
+	}
+
+	if err := UpsertConfigMap(cm.Data, "wsm-deployment-marker", namespace); err != nil {
+		return fmt.Errorf("failed to update deployment marker: %w", err)
+	}
+	return nil
+}
+
 // FindNamespacesWithMarker finds all namespaces containing the wsm-deployment-marker for a specific component
 func FindNamespacesWithMarker(ctx context.Context, component string) ([]string, error) {
 	cms, err := ListConfigMaps(ctx, "wsm-deployment-marker")

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -770,6 +770,10 @@ func DeployOperator(
 	telemetry TelemetryConfig,
 	wandbNamespace string,
 	openshift bool,
+	enableMocoOperator bool,
+	enableRedisOperator bool,
+	enableSeaweedfsOperator bool,
+	enableClickhouseOperator bool,
 ) error {
 	const chartName = "operator"
 	const releaseName = "wandb-operator"
@@ -895,6 +899,30 @@ func DeployOperator(
 
 	if openshift {
 		applyOpenShiftValues(releaseValues)
+	}
+
+	// Disable any bundled managed-service operator subcharts the caller opted out of
+	// (e.g. bring-your-own MySQL). Applied after the mirror and openshift blocks so
+	// these win. Each disable sets two values: the subchart's own condition
+	// (<subchart>.enabled=false, stops the pod) and the W&B controller's per-service
+	// toggle (wandb-operator.operators.<key>=false, stops it managing that service).
+	// setNested writes the leaf without clobbering sibling keys (e.g. the mirror-set
+	// image repositories), so multiple disables compose correctly.
+	if !enableMocoOperator {
+		setNested(releaseValues, false, "moco", "enabled")
+		setNested(releaseValues, false, "wandb-operator", "operators", "mysql")
+	}
+	if !enableRedisOperator {
+		setNested(releaseValues, false, "redis-operator", "enabled")
+		setNested(releaseValues, false, "wandb-operator", "operators", "redis")
+	}
+	if !enableSeaweedfsOperator {
+		setNested(releaseValues, false, "seaweedfs-operator", "enabled")
+		setNested(releaseValues, false, "wandb-operator", "operators", "objectStore")
+	}
+	if !enableClickhouseOperator {
+		setNested(releaseValues, false, "altinity-clickhouse-operator", "enabled")
+		setNested(releaseValues, false, "wandb-operator", "operators", "clickhouse")
 	}
 
 	if releaseExists {


### PR DESCRIPTION
# Summary of Changes

Adds four typed flags to `wsm deploy-v2 operator` so users bringing their own managed services can skip the bundled subcharts, instead of hand-editing chart values.

- **New flags** (default `true`): `--enable-moco-operator`, `--enable-redis-operator`, `--enable-seaweedfs-operator`, `--enable-clickhouse-operator`. A normal install needs none of them.
- **Two values per disable:** each sets `<subchart>.enabled=false` (stops the operator pod installing) and `wandb-operator.operators.<key>=false` (stops the W&B controller managing that service), applied via `setNested` after the mirror/OpenShift blocks so they win and compose without clobbering sibling keys.
- **Choices persist:** the disabled set is stored in the `wsm-deployment-marker` ConfigMap (`disabled-subcharts` key), so a later flag-less `wsm deploy-v2 operator` upgrade keeps a subchart disabled; passing the flag again with `=true` re-enables it, and `operator destroy` clears the state. An explicit flag on any run always wins over the persisted value.
- Note: `--enable-seaweedfs-operator=false` also drops `prometheus-operator-crds`, which shares the same chart condition.

# Test Plan

- `make build` — compiles clean
- `make lint` — `go vet` + golangci-lint clean (0 issues)
- `make fmt` — no diff
- `go mod tidy` — no diff
- Kind smoke test (v2), each verified via `helm get values`, pod state, and the marker ConfigMap:
  - each flag individually `=false` → that subchart's pod gone, others running
  - all four `=false` → all gone, `operators.*` all false (no clobber)
  - persistence: flag-less re-run keeps prior disables
  - re-enable `=true` → subcharts return, marker cleared
  - `operator destroy` → marker state cleared
  - invalid bool value → rejected before any cluster change

# Requirements

- [x] Lint clean (`make lint`)
- [x] Format clean (`make fmt` leaves no diff)
- [x] `go.mod` / `go.sum` tidy (`go mod tidy` leaves no diff)
- [x] I/AI have tested the changes on this PR
- [x] Docs (`docs/`, `docs/reference/commands.md`, `docs/reference/cr-fields.md`) / `CLAUDE.md` updated if behavior changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to enable or disable the bundled MySQL, Redis, SeaweedFS, and ClickHouse operators during deployment.
  * Deployment choices are preserved for future upgrades when flags are omitted.
  * Uninstalling clears saved operator selections so reinstallations start with default settings.
  * Added support for using external MySQL and object storage services.

* **Documentation**
  * Updated command reference, OpenShift compatibility details, available flags, examples, and persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->