### PR TITLE
refactor(deploy-v2): make default --size a constant, set to dev

### DIFF
--- a/cmd/wsm/deploy_v2.go
+++ b/cmd/wsm/deploy_v2.go
@@ -50,6 +50,9 @@ const (
 	minWandbVersion     = "0.80.0"
 )
 
+// defaultWandbSize is stamped into spec.size when --size is unset.
+const defaultWandbSize = v2.SizeDev
+
 const (
 	certManagerInstallModeAuto  = "auto"
 	certManagerInstallModeTrue  = "true"
@@ -157,7 +160,7 @@ func DeployV2Cmd() *cobra.Command {
 	// `operator` alone (see operatorDeployCmd) since that is the only command that applies them.
 	cmd.PersistentFlags().String("observability-mode", "off", "Enable observability for applications (off, full, forward)")
 	cmd.PersistentFlags().String("retention-policy", "detach", "Retention policy for W&B instance (detach, purge) - defaults to detach")
-	cmd.PersistentFlags().String("size", "small", "W&B instance size (dev, micro, small, medium, large, xlarge, xxlarge)")
+	cmd.PersistentFlags().String("size", string(defaultWandbSize), "W&B instance size (dev, micro, small, medium, large, xlarge, xxlarge)")
 	cmd.PersistentFlags().String("object-store-storage-size", "", "Override the managed object store (SeaweedFS) storage size, e.g. 20Gi. Must be < 30Gi: the operator derives SeaweedFS volumeSizeLimitMB from this and the master rejects a limit >= 30000. Leave empty to use the size preset's default.")
 	cmd.PersistentFlags().String("wandb-hostname", "http://localhost:8080", "Hostname to use for the W&B instance")
 	cmd.PersistentFlags().String("wandb-name", "wandb", "Name of the W&B instance")

--- a/docs/getting-started/quickstart-kind.md
+++ b/docs/getting-started/quickstart-kind.md
@@ -82,7 +82,7 @@ The quick-start deployment uses these defaults:
 | **Instance Name** | `wandb` |
 | **Namespace** | `wandb` |
 | **Operator Namespace** | `wandb-operators` |
-| **Size** | `small` |
+| **Size** | `dev` |
 | **Version** | `0.79.2` (latest stable) |
 | **Gateway Class** | `nginx` |
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -148,7 +148,7 @@ wsm deploy-v2 wandb deploy [flags]
 | `--wandb-version` | — | Server manifest version (defaults to built-in stable version) |
 | `--mirror-registry` | — | Install the W&B instance from this mirror. Defaults `--manifest-repository` to `oci://<mirror>/wandb/server-manifest` (charts, operator/infra images, and the rewritten app images come from the mirror). The managed data-plane images (ClickHouse/MySQL/Redis/SeaweedFS/Kafka) keep their upstream refs and reach the mirror via each node's container-runtime registry mirror — not `spec.global.imageRegistry`. Populate the mirror first with `wsm registry mirror`. |
 | `--manifest-repository` | — | Server manifest source. Accepts an OCI repository (`oci://…`, pulled over HTTPS) **or** a local `file://` path mounted onto the operator pod (the no-TLS option for plain-HTTP / insecure air-gap installs; a plain-HTTP `oci://` mirror is rejected). Auto-set to `oci://<mirror>/wandb/server-manifest` when `--mirror-registry` is provided and this is unset. |
-| `--size` | `small` | Deployment size profile: `dev`, `micro`, `small`, `medium`, `large`, `xlarge`, `xxlarge` |
+| `--size` | `dev` | Deployment size profile: `dev`, `micro`, `small`, `medium`, `large`, `xlarge`, `xxlarge` |
 | `--license` | — | W&B license string |
 | `--license-file` | — | Path to a file containing the W&B license |
 | `--oidc-client-id` | — | OIDC client ID as `<secret-name>:<key>` (`spec.wandb.oidc.clientId`). Optional; leave unset to disable OIDC. Ignored for any leaf already set via `--cr-file` |


### PR DESCRIPTION
# Summary of Changes

**Jira:** [ONPREM-XXXX](https://coreweave.atlassian.net/browse/ONPREM-XXXX)

The default W&B instance `--size` was inlined as the string `"small"` in the flag registration. This change introduces a typed `defaultWandbSize` constant (`= v2.SizeDev`) alongside the other hand-bumped constants near the top of `deploy_v2.go`, so the default resource profile can be reset in one obvious place, and moves the default from `small` to `dev` (the minimal profile the Kind getting-started path already uses explicitly). `dev` is already an accepted value in `validateSize`, so no validation change was needed. The two docs that state the default (`commands.md`, `quickstart-kind.md`) are updated to match.

# Test Plan

- `make build` — compiles clean.
- `./wsm deploy-v2 wandb deploy --help` — confirms `--size` now shows `(default "dev")`.
- `make lint` — 0 issues.
- `make fmt` — no diff on the changed Go file.
- `go mod tidy` — no diff.

# Requirements

- [x] Lint clean (`make lint`)
- [x] Format clean (`make fmt` leaves no diff)
- [x] `go.mod` / `go.sum` tidy (`go mod tidy` leaves no diff)
- [x] I/AI have tested the changes on this PR
- [x] Docs (`docs/`, `docs/reference/commands.md`, `docs/reference/cr-fields.md`) / `CLAUDE.md` updated if behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated `deploy-v2` to use the **dev** deployment size by default when no size is specified.
  * Updated quick-start and command reference documentation to reflect the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->