### PR TITLE
chore: remove PR Checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -118,51 +118,6 @@ jobs:
               core.info(`PR title OK — type=${m[1]} scope=${m[2] || "none"} breaking=${m[3] ? "yes" : "no"}.`);
             }
 
-  pr-commits:
-    name: PR Commits
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        with:
-          script: |
-            // Bots use their own commit format; exempt them. Exit success rather than skip —
-            // a skipped required check blocks the merge gate.
-            const author = (context.payload.pull_request.user || {}).login || "";
-            const exemptAuthors = (process.env.EXEMPT_AUTHORS || "").split(/\s+/).filter(Boolean);
-            if (exemptAuthors.includes(author)) {
-              core.info(`Skipping PR Commits check for exempt PR (author=${author}).`);
-              return;
-            }
-
-            const { data: commits } = await github.rest.pulls.listCommits({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              per_page: 100,
-            });
-            const types = "feat|fix|build|chore|ci|docs|perf|refactor|revert|style|test";
-            const re = new RegExp(`^(${types})(\\([a-z0-9 ._-]+\\))?(!)?: (.+)$`);
-            const bad = [];
-            for (const c of commits) {
-              const subject = c.commit.message.split("\n")[0];
-              if (/^(Merge|fixup!|squash!)/.test(subject)) continue; // skip merge/autosquash commits
-              const m = subject.match(re);
-              if (!m) {
-                bad.push(`${c.sha.slice(0, 7)}  "${subject}"  -> not a Conventional Commit`);
-              } else if (/[.]$/.test(m[4].trim())) {
-                bad.push(`${c.sha.slice(0, 7)}  "${subject}"  -> drop trailing period`);
-              }
-            }
-            if (bad.length) {
-              core.setFailed(
-                `Invalid commit message(s) — keep the branch history Conventional-Commit clean:\n` +
-                bad.map((b) => "  " + b).join("\n") +
-                `\nFormat: type(scope)!: description (types: ${types.replace(/\|/g, ", ")})`
-              );
-            } else {
-              core.info(`All ${commits.length} commit subject(s) OK.`);
-            }
-
   pr-release-label:
     name: Release Label
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
PR TITLE must follow Conventional Commits + Graphite style, e.g.
  feat(deploy-v2): add kind cluster picker
  • format: type(scope)!: imperative, lowercase description (no trailing period, <= 72 chars)
  • types: feat fix build chore ci docs perf refactor revert style test
  • https://www.conventionalcommits.org/en/v1.0.0/
  • https://graphite.com/guides/best-pr-title-guidelines

RELEASE LABEL required — the PR Checks gate fails without exactly one of:
  release:major  release:minor  release:patch  release:skip
release-on-merge.yaml reads it to decide the version bump cut on merge to main.
-->

# Summary of Changes

**Jira:** [ONPREM-XXXX](https://coreweave.atlassian.net/browse/ONPREM-XXXX)

We removed the PR Check for checking each commit as it was unnecessary 

# Test Plan

<!--
How was this tested? There is no unit-test suite; give the actual commands/steps:
  • make build          — compiles clean
  • make lint           — go vet + golangci-lint clean
  • ./wsm list          — v1 sanity, no cluster needed
  • Kind smoke test     — v2 (deploy-v2 operator / wandb deploy) against a local cluster
-->

None required

# Requirements

<!-- Every box must be checked before this PR can merge. -->

- [x] Lint clean (`make lint`)
- [x] Format clean (`make fmt` leaves no diff)
- [x] `go.mod` / `go.sum` tidy (`go mod tidy` leaves no diff)
- [x] I/AI have tested the changes on this PR
- [x] Docs (`docs/`, `docs/reference/commands.md`, `docs/reference/cr-fields.md`) / `CLAUDE.md` updated if behavior changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the pull request commit validation check from the automated checks workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->