### PR TITLE
feat(registry): derive all images and tags from manifest/charts

### DIFF
--- a/cmd/wsm/registry.go
+++ b/cmd/wsm/registry.go
@@ -135,12 +135,25 @@ func registryCheckCmd() *cobra.Command {
 			// check and mirror always agree. (The old path discovered a different,
 			// v1-derived image set under different names, so it reported every
 			// freshly-mirrored image as "missing".)
+			// Render the charts FROM THE MIRROR so check needs only registry access.
 			var targets []string
-			for _, it := range buildMirrorPlan(registry, operatorChartVersion) {
+			mirrorPlan, err := buildMirrorPlan(ctx, registry, operatorChartVersion, true, insecure)
+			if err != nil {
+				return err
+			}
+			for _, it := range mirrorPlan {
 				targets = append(targets, it.dst)
 			}
 			if !skipManaged {
-				for _, it := range buildManagedImagePlan(registry) {
+				// Render the operator chart FROM THE MIRROR (its bundled subcharts
+				// travel with it), so check needs only registry access — no upstream.
+				// The rendered image refs are upstream regardless of chart source, so
+				// they translate to the same mirror destinations.
+				managed, err := buildManagedImagePlan(ctx, registry, "oci://"+registry+"/wandb/charts", operatorChartVersion, insecure)
+				if err != nil {
+					return err
+				}
+				for _, it := range managed {
 					targets = append(targets, it.dst)
 				}
 			}
@@ -157,7 +170,7 @@ func registryCheckCmd() *cobra.Command {
 				files, err := pullManifestYAMLFrom(ctx, manifestRepo, wandbVersion, insecure)
 				if err != nil {
 					manifestWarn = fmt.Sprintf("could not read server manifest %s:%s — application images not checked (%v)", manifestRepo, wandbVersion, err)
-				} else if refs, err := collectManifestImages(files); err != nil {
+				} else if refs, err := collectManifestImages(files, !skipManaged); err != nil {
 					manifestWarn = fmt.Sprintf("could not parse server manifest %s:%s — application images not checked (%v)", manifestRepo, wandbVersion, err)
 				} else {
 					for _, r := range refs {

--- a/cmd/wsm/registry.go
+++ b/cmd/wsm/registry.go
@@ -133,7 +133,7 @@ func registryCheckCmd() *cobra.Command {
 			registry = strings.TrimRight(registry, "/")
 			ctx := context.Background()
 
-			ex, err := parseManagedExclusions(excludeOperators, excludeManaged, skipManaged)
+			exclusions, err := parseManagedExclusions(excludeOperators, excludeManaged, skipManaged)
 			if err != nil {
 				return err
 			}
@@ -151,11 +151,8 @@ func registryCheckCmd() *cobra.Command {
 			for _, it := range mirrorPlan {
 				targets = append(targets, it.dst)
 			}
-			// Render the operator chart FROM THE MIRROR (its bundled subcharts travel
-			// with it), so check needs only registry access — no upstream. The rendered
-			// image refs are upstream regardless of chart source, so they translate to
-			// the same mirror destinations. Excluded operators are dropped per ex.
-			managed, err := buildManagedImagePlan(ctx, registry, "oci://"+registry+"/wandb/charts", operatorChartVersion, ex, insecure)
+			// Operator chart also rendered from the mirror's copy (its subcharts travel with it).
+			managed, err := buildManagedImagePlan(ctx, registry, "oci://"+registry+"/wandb/charts", operatorChartVersion, exclusions, insecure)
 			if err != nil {
 				return err
 			}
@@ -175,7 +172,7 @@ func registryCheckCmd() *cobra.Command {
 				files, err := pullManifestYAMLFrom(ctx, manifestRepo, wandbVersion, insecure)
 				if err != nil {
 					manifestWarn = fmt.Sprintf("could not read server manifest %s:%s — application images not checked (%v)", manifestRepo, wandbVersion, err)
-				} else if refs, err := collectManifestImages(files, ex); err != nil {
+				} else if refs, err := collectManifestImages(files, exclusions); err != nil {
 					manifestWarn = fmt.Sprintf("could not parse server manifest %s:%s — application images not checked (%v)", manifestRepo, wandbVersion, err)
 				} else {
 					for _, r := range refs {

--- a/cmd/wsm/registry.go
+++ b/cmd/wsm/registry.go
@@ -101,6 +101,8 @@ func registryCheckCmd() *cobra.Command {
 		operatorChartVersion string
 		wandbVersion         string
 		skipManaged          bool
+		excludeOperators     []string
+		excludeManaged       []string
 	)
 
 	cmd := &cobra.Command{
@@ -131,6 +133,11 @@ func registryCheckCmd() *cobra.Command {
 			registry = strings.TrimRight(registry, "/")
 			ctx := context.Background()
 
+			ex, err := parseManagedExclusions(excludeOperators, excludeManaged, skipManaged)
+			if err != nil {
+				return err
+			}
+
 			// Build the same destination set 'wsm registry mirror' pushes, so
 			// check and mirror always agree. (The old path discovered a different,
 			// v1-derived image set under different names, so it reported every
@@ -144,18 +151,16 @@ func registryCheckCmd() *cobra.Command {
 			for _, it := range mirrorPlan {
 				targets = append(targets, it.dst)
 			}
-			if !skipManaged {
-				// Render the operator chart FROM THE MIRROR (its bundled subcharts
-				// travel with it), so check needs only registry access — no upstream.
-				// The rendered image refs are upstream regardless of chart source, so
-				// they translate to the same mirror destinations.
-				managed, err := buildManagedImagePlan(ctx, registry, "oci://"+registry+"/wandb/charts", operatorChartVersion, insecure)
-				if err != nil {
-					return err
-				}
-				for _, it := range managed {
-					targets = append(targets, it.dst)
-				}
+			// Render the operator chart FROM THE MIRROR (its bundled subcharts travel
+			// with it), so check needs only registry access — no upstream. The rendered
+			// image refs are upstream regardless of chart source, so they translate to
+			// the same mirror destinations. Excluded operators are dropped per ex.
+			managed, err := buildManagedImagePlan(ctx, registry, "oci://"+registry+"/wandb/charts", operatorChartVersion, ex, insecure)
+			if err != nil {
+				return err
+			}
+			for _, it := range managed {
+				targets = append(targets, it.dst)
 			}
 
 			// The application images are listed inside the mirrored server
@@ -170,7 +175,7 @@ func registryCheckCmd() *cobra.Command {
 				files, err := pullManifestYAMLFrom(ctx, manifestRepo, wandbVersion, insecure)
 				if err != nil {
 					manifestWarn = fmt.Sprintf("could not read server manifest %s:%s — application images not checked (%v)", manifestRepo, wandbVersion, err)
-				} else if refs, err := collectManifestImages(files, !skipManaged); err != nil {
+				} else if refs, err := collectManifestImages(files, ex); err != nil {
 					manifestWarn = fmt.Sprintf("could not parse server manifest %s:%s — application images not checked (%v)", manifestRepo, wandbVersion, err)
 				} else {
 					for _, r := range refs {
@@ -225,7 +230,9 @@ func registryCheckCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&failOnMissing, "fail-on-missing", false, "Exit non-zero if any artifact is missing")
 	cmd.Flags().StringVar(&operatorChartVersion, "operator-chart-version", "2.0.0-beta.3", "Operator chart version that was mirrored (must match 'wsm registry mirror')")
 	cmd.Flags().StringVar(&wandbVersion, "wandb-version", "", "W&B server version that was mirrored; when set, also check the server manifest and every application image it references")
-	cmd.Flags().BoolVar(&skipManaged, "skip-managed-images", false, "Don't check the managed-service operator + data-plane images (match the flag you mirrored with)")
+	cmd.Flags().BoolVar(&skipManaged, "skip-managed-images", false, "Alias for --exclude-managed clickhouse,mysql,redis,object-store (match the flag you mirrored with)")
+	cmd.Flags().StringSliceVar(&excludeOperators, "exclude-operators", nil, "Managed types whose operator images to skip checking (match --exclude-operators you mirrored with)")
+	cmd.Flags().StringSliceVar(&excludeManaged, "exclude-managed", nil, "Managed types to skip checking entirely (match --exclude-managed you mirrored with). Kafka cannot be excluded.")
 	return cmd
 }
 

--- a/cmd/wsm/registry_managed.go
+++ b/cmd/wsm/registry_managed.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// managedType describes a managed-service type that can be excluded from the
+// mirror. Kafka is deliberately NOT a managed type: its data-plane images are
+// always mirrored and it has no operator subchart.
+type managedType struct {
+	// subchart is the operator-chart dependency that installs this type's operator;
+	// disabling it (via <subchart>.enabled=false) drops the operator's images from
+	// the render.
+	subchart string
+}
+
+// managedTypes is the set of excludable managed-service types, keyed by the value
+// accepted on the --exclude-operators / --exclude-managed flags.
+var managedTypes = map[string]managedType{
+	"clickhouse":   {subchart: "altinity-clickhouse-operator"},
+	"mysql":        {subchart: "moco"},
+	"redis":        {subchart: "redis-operator"},
+	"object-store": {subchart: "seaweedfs-operator"},
+}
+
+func managedTypeNames() []string {
+	names := make([]string, 0, len(managedTypes))
+	for n := range managedTypes {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// managedExclusions records which managed-service types are excluded from the
+// mirror, along two independent axes:
+//
+//   - operators: skip the type's OPERATOR images only — the customer runs their own
+//     cluster-wide operator, but still uses W&B's managed data-plane service.
+//   - managed: skip the type ENTIRELY (operator + data-plane server images) — the
+//     customer brings an external service.
+//
+// Excluding a type's managed service implies excluding its now-purposeless
+// operator, so managed is a superset for the operator axis.
+type managedExclusions struct {
+	operators map[string]bool
+	managed   map[string]bool
+}
+
+// excludeOperator reports whether the type's operator images should be skipped.
+func (e managedExclusions) excludeOperator(t string) bool {
+	return e.operators[t] || e.managed[t]
+}
+
+// excludeServer reports whether the type's data-plane server images should be skipped.
+func (e managedExclusions) excludeServer(t string) bool {
+	return e.managed[t]
+}
+
+// disabledSubcharts returns the operator-chart subcharts to disable when rendering
+// the operator chart — one per type whose operator is excluded — so their operator
+// images (and, for moco, the injected sidecars) are not derived.
+func (e managedExclusions) disabledSubcharts() []string {
+	var out []string
+	for _, t := range managedTypeNames() {
+		if e.excludeOperator(t) {
+			out = append(out, managedTypes[t].subchart)
+		}
+	}
+	return out
+}
+
+// allOperatorsExcluded reports whether every managed operator is excluded, so the
+// operator chart need not be rendered for managed images at all.
+func (e managedExclusions) allOperatorsExcluded() bool {
+	for t := range managedTypes {
+		if !e.excludeOperator(t) {
+			return false
+		}
+	}
+	return true
+}
+
+// parseManagedExclusions validates the --exclude-operators / --exclude-managed
+// values (and the --skip-managed-images alias) into a managedExclusions. Unknown
+// types — including "kafka", which can never be excluded — are rejected.
+func parseManagedExclusions(excludeOperators, excludeManaged []string, skipManaged bool) (managedExclusions, error) {
+	ex := managedExclusions{operators: map[string]bool{}, managed: map[string]bool{}}
+
+	assign := func(flag string, values []string, dst map[string]bool) error {
+		for _, v := range values {
+			v = strings.TrimSpace(v)
+			if v == "" {
+				continue
+			}
+			if _, ok := managedTypes[v]; !ok {
+				if v == "kafka" {
+					return fmt.Errorf("%s: kafka cannot be excluded — its images are always mirrored", flag)
+				}
+				return fmt.Errorf("%s: unknown managed type %q (valid: %s)", flag, v, strings.Join(managedTypeNames(), ", "))
+			}
+			dst[v] = true
+		}
+		return nil
+	}
+
+	if err := assign("--exclude-operators", excludeOperators, ex.operators); err != nil {
+		return ex, err
+	}
+	if err := assign("--exclude-managed", excludeManaged, ex.managed); err != nil {
+		return ex, err
+	}
+	if skipManaged {
+		for t := range managedTypes {
+			ex.managed[t] = true
+		}
+	}
+	return ex, nil
+}

--- a/cmd/wsm/registry_managed.go
+++ b/cmd/wsm/registry_managed.go
@@ -41,8 +41,7 @@ type managedExclusions struct {
 	managed   map[string]bool
 }
 
-// excludeOperator reports whether the type's operator images should be skipped
-// (either axis excludes the operator).
+// excludeOperator is true when either axis excludes the type's operator.
 func (e managedExclusions) excludeOperator(t string) bool {
 	return e.operators[t] || e.managed[t]
 }

--- a/cmd/wsm/registry_managed.go
+++ b/cmd/wsm/registry_managed.go
@@ -6,13 +6,11 @@ import (
 	"strings"
 )
 
-// managedType describes a managed-service type that can be excluded from the
-// mirror. Kafka is deliberately NOT a managed type: its data-plane images are
-// always mirrored and it has no operator subchart.
+// managedType is an excludable managed-service type. Kafka is deliberately not one:
+// its data-plane images are always mirrored and it has no operator subchart.
 type managedType struct {
-	// subchart is the operator-chart dependency that installs this type's operator;
-	// disabling it (via <subchart>.enabled=false) drops the operator's images from
-	// the render.
+	// subchart is the operator-chart dependency for this type's operator, disabled
+	// via <subchart>.enabled=false to drop its images from the render.
 	subchart string
 }
 
@@ -34,34 +32,27 @@ func managedTypeNames() []string {
 	return names
 }
 
-// managedExclusions records which managed-service types are excluded from the
-// mirror, along two independent axes:
-//
-//   - operators: skip the type's OPERATOR images only — the customer runs their own
-//     cluster-wide operator, but still uses W&B's managed data-plane service.
-//   - managed: skip the type ENTIRELY (operator + data-plane server images) — the
-//     customer brings an external service.
-//
-// Excluding a type's managed service implies excluding its now-purposeless
-// operator, so managed is a superset for the operator axis.
+// managedExclusions records excluded managed-service types along two axes:
+// operators (skip the operator images only — customer runs their own operator) and
+// managed (skip the type entirely — customer brings an external service). Excluding
+// the managed service implies excluding its operator.
 type managedExclusions struct {
 	operators map[string]bool
 	managed   map[string]bool
 }
 
-// excludeOperator reports whether the type's operator images should be skipped.
+// excludeOperator reports whether the type's operator images should be skipped
+// (either axis excludes the operator).
 func (e managedExclusions) excludeOperator(t string) bool {
 	return e.operators[t] || e.managed[t]
 }
 
-// excludeServer reports whether the type's data-plane server images should be skipped.
 func (e managedExclusions) excludeServer(t string) bool {
 	return e.managed[t]
 }
 
-// disabledSubcharts returns the operator-chart subcharts to disable when rendering
-// the operator chart — one per type whose operator is excluded — so their operator
-// images (and, for moco, the injected sidecars) are not derived.
+// disabledSubcharts returns the subcharts to disable when rendering the operator
+// chart, one per type whose operator is excluded.
 func (e managedExclusions) disabledSubcharts() []string {
 	var out []string
 	for _, t := range managedTypeNames() {
@@ -72,8 +63,7 @@ func (e managedExclusions) disabledSubcharts() []string {
 	return out
 }
 
-// allOperatorsExcluded reports whether every managed operator is excluded, so the
-// operator chart need not be rendered for managed images at all.
+// allOperatorsExcluded reports whether the operator chart can be skipped entirely.
 func (e managedExclusions) allOperatorsExcluded() bool {
 	for t := range managedTypes {
 		if !e.excludeOperator(t) {
@@ -87,7 +77,7 @@ func (e managedExclusions) allOperatorsExcluded() bool {
 // values (and the --skip-managed-images alias) into a managedExclusions. Unknown
 // types — including "kafka", which can never be excluded — are rejected.
 func parseManagedExclusions(excludeOperators, excludeManaged []string, skipManaged bool) (managedExclusions, error) {
-	ex := managedExclusions{operators: map[string]bool{}, managed: map[string]bool{}}
+	exclusions := managedExclusions{operators: map[string]bool{}, managed: map[string]bool{}}
 
 	assign := func(flag string, values []string, dst map[string]bool) error {
 		for _, v := range values {
@@ -106,16 +96,16 @@ func parseManagedExclusions(excludeOperators, excludeManaged []string, skipManag
 		return nil
 	}
 
-	if err := assign("--exclude-operators", excludeOperators, ex.operators); err != nil {
-		return ex, err
+	if err := assign("--exclude-operators", excludeOperators, exclusions.operators); err != nil {
+		return exclusions, err
 	}
-	if err := assign("--exclude-managed", excludeManaged, ex.managed); err != nil {
-		return ex, err
+	if err := assign("--exclude-managed", excludeManaged, exclusions.managed); err != nil {
+		return exclusions, err
 	}
 	if skipManaged {
 		for t := range managedTypes {
-			ex.managed[t] = true
+			exclusions.managed[t] = true
 		}
 	}
-	return ex, nil
+	return exclusions, nil
 }

--- a/cmd/wsm/registry_managed_test.go
+++ b/cmd/wsm/registry_managed_test.go
@@ -25,53 +25,53 @@ func TestParseManagedExclusions_Unknown(t *testing.T) {
 
 func TestManagedExclusions_Semantics(t *testing.T) {
 	// --exclude-operators mysql: operator skipped, server kept.
-	ex, err := parseManagedExclusions([]string{"mysql"}, nil, false)
+	exclusions, err := parseManagedExclusions([]string{"mysql"}, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ex.excludeOperator("mysql") {
+	if !exclusions.excludeOperator("mysql") {
 		t.Error("mysql operator should be excluded")
 	}
-	if ex.excludeServer("mysql") {
+	if exclusions.excludeServer("mysql") {
 		t.Error("mysql server should NOT be excluded by --exclude-operators")
 	}
 
 	// --exclude-managed redis: both operator and server skipped.
-	ex, err = parseManagedExclusions(nil, []string{"redis"}, false)
+	exclusions, err = parseManagedExclusions(nil, []string{"redis"}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ex.excludeOperator("redis") || !ex.excludeServer("redis") {
+	if !exclusions.excludeOperator("redis") || !exclusions.excludeServer("redis") {
 		t.Error("--exclude-managed redis should exclude both operator and server")
 	}
 }
 
 func TestManagedExclusions_SkipAllAliasAndSubcharts(t *testing.T) {
-	ex, err := parseManagedExclusions(nil, nil, true) // --skip-managed-images
+	exclusions, err := parseManagedExclusions(nil, nil, true) // --skip-managed-images
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !ex.allOperatorsExcluded() {
+	if !exclusions.allOperatorsExcluded() {
 		t.Error("--skip-managed-images should exclude all operators")
 	}
 	for _, tp := range []string{"clickhouse", "mysql", "redis", "object-store"} {
-		if !ex.excludeServer(tp) {
+		if !exclusions.excludeServer(tp) {
 			t.Errorf("--skip-managed-images should exclude server %q", tp)
 		}
 	}
 
 	// disabledSubcharts maps the excluded operator types to their subchart names.
-	ex, err = parseManagedExclusions([]string{"mysql", "clickhouse"}, nil, false)
+	exclusions, err = parseManagedExclusions([]string{"mysql", "clickhouse"}, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	got := ex.disabledSubcharts()
+	got := exclusions.disabledSubcharts()
 	sort.Strings(got)
 	want := []string{"altinity-clickhouse-operator", "moco"}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Errorf("disabledSubcharts = %v, want %v", got, want)
 	}
-	if ex.allOperatorsExcluded() {
+	if exclusions.allOperatorsExcluded() {
 		t.Error("only two of four types excluded — allOperatorsExcluded should be false")
 	}
 }

--- a/cmd/wsm/registry_managed_test.go
+++ b/cmd/wsm/registry_managed_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestParseManagedExclusions_KafkaRejected(t *testing.T) {
+	if _, err := parseManagedExclusions([]string{"kafka"}, nil, false); err == nil {
+		t.Error("--exclude-operators kafka should be rejected")
+	} else if !strings.Contains(err.Error(), "kafka cannot be excluded") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if _, err := parseManagedExclusions(nil, []string{"kafka"}, false); err == nil {
+		t.Error("--exclude-managed kafka should be rejected")
+	}
+}
+
+func TestParseManagedExclusions_Unknown(t *testing.T) {
+	if _, err := parseManagedExclusions(nil, []string{"postgres"}, false); err == nil {
+		t.Error("unknown managed type should be rejected")
+	}
+}
+
+func TestManagedExclusions_Semantics(t *testing.T) {
+	// --exclude-operators mysql: operator skipped, server kept.
+	ex, err := parseManagedExclusions([]string{"mysql"}, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ex.excludeOperator("mysql") {
+		t.Error("mysql operator should be excluded")
+	}
+	if ex.excludeServer("mysql") {
+		t.Error("mysql server should NOT be excluded by --exclude-operators")
+	}
+
+	// --exclude-managed redis: both operator and server skipped.
+	ex, err = parseManagedExclusions(nil, []string{"redis"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ex.excludeOperator("redis") || !ex.excludeServer("redis") {
+		t.Error("--exclude-managed redis should exclude both operator and server")
+	}
+}
+
+func TestManagedExclusions_SkipAllAliasAndSubcharts(t *testing.T) {
+	ex, err := parseManagedExclusions(nil, nil, true) // --skip-managed-images
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ex.allOperatorsExcluded() {
+		t.Error("--skip-managed-images should exclude all operators")
+	}
+	for _, tp := range []string{"clickhouse", "mysql", "redis", "object-store"} {
+		if !ex.excludeServer(tp) {
+			t.Errorf("--skip-managed-images should exclude server %q", tp)
+		}
+	}
+
+	// disabledSubcharts maps the excluded operator types to their subchart names.
+	ex, err = parseManagedExclusions([]string{"mysql", "clickhouse"}, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := ex.disabledSubcharts()
+	sort.Strings(got)
+	want := []string{"altinity-clickhouse-operator", "moco"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("disabledSubcharts = %v, want %v", got, want)
+	}
+	if ex.allOperatorsExcluded() {
+		t.Error("only two of four types excluded — allOperatorsExcluded should be false")
+	}
+}

--- a/cmd/wsm/registry_manifest.go
+++ b/cmd/wsm/registry_manifest.go
@@ -30,6 +30,8 @@ import (
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
 	"oras.land/oras-go/v2/registry/remote/retry"
+
+	yamlv3 "gopkg.in/yaml.v3"
 	"sigs.k8s.io/yaml"
 )
 
@@ -54,7 +56,7 @@ const wandbPublicPrefix = "us-docker.pkg.dev/wandb-production/public/"
 func mirrorServerManifest(
 	ctx context.Context,
 	target, version, manifestSource string,
-	insecure, dryRun bool,
+	includeManaged, insecure, dryRun bool,
 	srcCtx, dstCtx *types.SystemContext,
 	policyCtx *signature.PolicyContext,
 ) error {
@@ -79,7 +81,7 @@ func mirrorServerManifest(
 		return fmt.Errorf("pull server manifest: %w", err)
 	}
 
-	refs, err := collectManifestImages(files)
+	refs, err := collectManifestImages(files, includeManaged)
 	if err != nil {
 		return fmt.Errorf("enumerate manifest images: %w", err)
 	}
@@ -87,14 +89,25 @@ func mirrorServerManifest(
 		return fmt.Errorf("server manifest %s:%s referenced no images", source, version)
 	}
 
-	// Map each unique source repository to its mirror location once; the same
-	// mapping drives both image copying and the in-manifest rewrite.
-	repoRewrite := map[string]string{}
-	for _, ref := range refs {
-		repoRewrite[ref.Repository] = rewriteRepoForMirror(target, ref.Repository)
+	// When mirroring the managed data-plane images, require the manifest to
+	// publish the ones the operator would otherwise resolve from an internal
+	// constant wsm cannot see (ClickHouse Keeper). Fail early with a clear
+	// message rather than producing an incomplete mirror.
+	if includeManaged {
+		if err := checkClickhouseKeeper(files); err != nil {
+			return err
+		}
 	}
 
-	fmt.Printf("  %d application image(s) referenced:\n", len(refs))
+	// Map each unique upstream ref (by full source image) to its mirror
+	// repository once; the same mapping drives both image copying and the
+	// in-manifest rewrite so they cannot drift.
+	mirrored := map[string]string{}
+	for _, ref := range refs {
+		mirrored[ref.GetImage("")] = rewriteRepoForMirror(target, upstreamRepo(ref))
+	}
+
+	fmt.Printf("  %d image(s) referenced:\n", len(refs))
 	for _, ref := range refs {
 		src := ref.GetImage("")
 		dst := mirrorImageRef(target, ref)
@@ -126,10 +139,13 @@ func mirrorServerManifest(
 
 	// Rewrite the manifest YAML files and re-push as a fresh OCI artifact.
 	rewritten := map[string][]byte{}
-	for name, data := range files {
-		out := data
-		for oldRepo, newRepo := range repoRewrite {
-			out = replaceRepo(out, oldRepo, newRepo)
+	for _, name := range sortedKeys(files) {
+		out, unknown, err := rewriteManifestImages(files[name], mirrored)
+		if err != nil {
+			return fmt.Errorf("rewrite %s: %w", name, err)
+		}
+		for _, u := range unknown {
+			fmt.Printf("  ⚠ %s references %s, which is not in the mirror plan — left unrewritten\n", name, u)
 		}
 		rewritten[name] = out
 	}
@@ -338,8 +354,12 @@ func extractManifestYAML(ctx context.Context, fetcher content.Fetcher, desc ocis
 
 // collectManifestImages parses each manifest YAML file and returns the unique
 // image references across applications (including init/sidecar containers) and
-// migration jobs.
-func collectManifestImages(files map[string][]byte) ([]wmanifest.ImageRef, error) {
+// migration jobs. When includeManaged is true it also enumerates the managed
+// data-plane images the operator reads from the manifest's infra sections
+// (object store, ClickHouse, MySQL, Redis, Kafka) — the tier-3 images wsm used
+// to hard-code. includeManaged should track --skip-managed-images so mirror and
+// check agree on the set.
+func collectManifestImages(files map[string][]byte, includeManaged bool) ([]wmanifest.ImageRef, error) {
 	seen := map[string]struct{}{}
 	var refs []wmanifest.ImageRef
 	add := func(ref wmanifest.ImageRef) {
@@ -372,8 +392,105 @@ func collectManifestImages(files map[string][]byte) ([]wmanifest.ImageRef, error
 		for _, mig := range m.Migrations {
 			add(mig.Image)
 		}
+		if includeManaged {
+			addInfraImages(m, add)
+		}
 	}
 	return refs, nil
+}
+
+// addInfraImages enumerates the managed data-plane images the operator pulls
+// straight from the manifest's infra sections. The MySQL "exporter" key is
+// deliberately skipped: moco exposes no per-cluster exporter-image override
+// (moco v0.34.0), so the operator ignores mysql.*.images.exporter and always
+// deploys the moco-chart exporter — mirroring the manifest value would push an
+// image that is never pulled. TODO: remove the skip once the manifest stops
+// emitting mysql.*.images.exporter. (The moco sidecars — agent/fluent-bit/the
+// real exporter — and every managed *operator* image are chart-derived, not
+// manifest-derived, so they are handled separately.)
+func addInfraImages(m wmanifest.Manifest, add func(wmanifest.ImageRef)) {
+	addSection := func(cfgs map[string]wmanifest.InfraConfig, skip map[string]bool) {
+		for _, inst := range sortedInstanceKeys(cfgs) {
+			images := cfgs[inst].Images
+			for _, key := range sortedImageKeys(images) {
+				if skip[key] {
+					continue
+				}
+				add(images[key])
+			}
+		}
+	}
+	addSection(m.Bucket, nil)
+	addSection(m.Clickhouse, nil)
+	addSection(m.ClickhouseKeeper, nil)
+	addSection(m.Mysql, map[string]bool{"exporter": true})
+	addSection(m.Redis, nil)
+	for _, key := range sortedImageKeys(m.Kafka.Images) {
+		add(m.Kafka.Images[key])
+	}
+}
+
+func sortedInstanceKeys(m map[string]wmanifest.InfraConfig) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedImageKeys(m map[string]wmanifest.ImageRef) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// upstreamRepo returns an image ref's full source repository, folding a split-out
+// registry host back into the path (docker.io/altinity/clickhouse-server) so both
+// the legacy embedded encoding and the newer registry/repository split map through
+// rewriteRepoForMirror identically.
+func upstreamRepo(ref wmanifest.ImageRef) string {
+	if ref.Registry != "" {
+		return ref.Registry + "/" + ref.Repository
+	}
+	return ref.Repository
+}
+
+// checkClickhouseKeeper rejects a manifest that deploys managed ClickHouse but
+// does not publish a Keeper image. Server manifests before ~0.84 left the
+// clickhouseKeeper section empty and the operator fell back to an internal
+// (unexported) constant wsm cannot read — so wsm could not mirror the Keeper image
+// the operator will actually pull. Requiring the image in the manifest keeps the
+// mirror complete; the fix is to mirror with W&B server >= 0.84.0. Values are
+// merged across every manifest file before deciding, since the two sections may
+// live in different files.
+func checkClickhouseKeeper(files map[string][]byte) error {
+	hasServer, hasKeeper := false, false
+	for _, name := range sortedKeys(files) {
+		var m wmanifest.Manifest
+		if err := yaml.Unmarshal(files[name], &m); err != nil {
+			return fmt.Errorf("parse %s: %w", name, err)
+		}
+		for _, inst := range m.Clickhouse {
+			if _, ok := inst.Images["server"]; ok {
+				hasServer = true
+			}
+		}
+		for _, inst := range m.ClickhouseKeeper {
+			if _, ok := inst.Images["keeper"]; ok {
+				hasKeeper = true
+			}
+		}
+	}
+	if hasServer && !hasKeeper {
+		return fmt.Errorf("server manifest does not publish a ClickHouse Keeper image " +
+			"(clickhouseKeeper.*.images.keeper); wsm cannot derive it. Mirror with W&B " +
+			"server version >= 0.84.0, or pass --skip-managed-images if you run external ClickHouse")
+	}
+	return nil
 }
 
 // rewriteRepoForMirror maps an upstream image repository to its location in the
@@ -395,54 +512,157 @@ func rewriteRepoForMirror(target, repo string) string {
 }
 
 // mirrorImageRef returns the full mirror reference (repo + tag/digest) for an
-// upstream image reference.
+// upstream image reference. It folds any split-out registry host into the path
+// first, so split (registry+repository) and legacy (embedded) refs land at the
+// same flattened <mirror>/<path> location.
 func mirrorImageRef(target string, ref wmanifest.ImageRef) string {
 	mirrored := wmanifest.ImageRef{
-		Repository: rewriteRepoForMirror(target, ref.Repository),
+		Repository: rewriteRepoForMirror(target, upstreamRepo(ref)),
 		Tag:        ref.Tag,
 		Digest:     ref.Digest,
 	}
 	return mirrored.GetImage("")
 }
 
-// replaceRepo replaces every standalone occurrence of oldRepo with newRepo in
-// data. A match is "standalone" only when neither the preceding nor following
-// byte continues a repository path, so replacing "…/weave-trace" never touches
-// "…/weave-trace-server".
-func replaceRepo(data []byte, oldRepo, newRepo string) []byte {
-	if oldRepo == "" || oldRepo == newRepo {
-		return data
+// rewriteManifestImages rewrites every mirrored image reference in one manifest
+// YAML file to point at the mirror, and drops the inert MySQL exporter image. It
+// edits the YAML node tree rather than the raw bytes so it handles both image-ref
+// encodings (legacy embedded repository, and the newer registry/repository split)
+// and preserves comments and any fields wsm's pinned manifest struct does not
+// model. mirrored maps an upstream ref's GetImage("") to its flattened mirror
+// repository; only refs present there are rewritten, guaranteeing every rewritten
+// ref was actually pushed. Refs not in mirrored are left untouched and returned so
+// the caller can warn. Returns the original bytes unchanged when nothing matched.
+func rewriteManifestImages(data []byte, mirrored map[string]string) ([]byte, []string, error) {
+	var doc yamlv3.Node
+	if err := yamlv3.Unmarshal(data, &doc); err != nil {
+		return nil, nil, err
 	}
-	old := []byte(oldRepo)
-	var out bytes.Buffer
-	for i := 0; i < len(data); {
-		if bytes.HasPrefix(data[i:], old) {
-			beforeOK := i == 0 || !isRepoPathByte(data[i-1])
-			afterIdx := i + len(old)
-			afterOK := afterIdx == len(data) || !isRepoPathByte(data[afterIdx])
-			if beforeOK && afterOK {
-				out.WriteString(newRepo)
-				i = afterIdx
-				continue
-			}
+	if len(doc.Content) == 0 {
+		return data, nil, nil
+	}
+	root := doc.Content[0]
+	pruneMysqlExporter(root)
+
+	var unknown []string
+	changed := false
+	forEachImageRefNode(root, func(n *yamlv3.Node) {
+		ref := nodeImageRef(n)
+		if ref.Repository == "" {
+			return
 		}
-		out.WriteByte(data[i])
-		i++
+		newRepo, ok := mirrored[ref.GetImage("")]
+		if !ok {
+			unknown = append(unknown, ref.GetImage(""))
+			return
+		}
+		setNodeMirrorRepo(n, newRepo)
+		changed = true
+	})
+
+	if !changed {
+		return data, unknown, nil
 	}
-	return out.Bytes()
+	out, err := yamlv3.Marshal(&doc)
+	if err != nil {
+		return nil, unknown, err
+	}
+	return out, unknown, nil
 }
 
-// isRepoPathByte reports whether b can appear inside a repository path segment
-// (used to detect token boundaries). ':' is deliberately excluded so a tag
-// separator counts as a boundary.
-func isRepoPathByte(b byte) bool {
-	switch {
-	case b >= 'a' && b <= 'z', b >= 'A' && b <= 'Z', b >= '0' && b <= '9':
-		return true
-	case b == '/', b == '.', b == '-', b == '_':
-		return true
-	default:
-		return false
+// pruneMysqlExporter removes the (inert) exporter entry from every mysql instance's
+// images map so no dead upstream ref survives in the mirrored manifest. See
+// addInfraImages for why the exporter image is not mirrored.
+func pruneMysqlExporter(root *yamlv3.Node) {
+	mysql := mappingValue(root, "mysql")
+	if mysql == nil || mysql.Kind != yamlv3.MappingNode {
+		return
+	}
+	for i := 1; i < len(mysql.Content); i += 2 {
+		inst := mysql.Content[i]
+		if inst.Kind != yamlv3.MappingNode {
+			continue
+		}
+		if images := mappingValue(inst, "images"); images != nil && images.Kind == yamlv3.MappingNode {
+			removeMappingKey(images, "exporter")
+		}
+	}
+}
+
+// forEachImageRefNode invokes fn on every mapping node that looks like an image
+// reference (has a "repository" key). It does not recurse into a matched node.
+func forEachImageRefNode(n *yamlv3.Node, fn func(*yamlv3.Node)) {
+	switch n.Kind {
+	case yamlv3.DocumentNode:
+		for _, c := range n.Content {
+			forEachImageRefNode(c, fn)
+		}
+	case yamlv3.MappingNode:
+		if mappingValue(n, "repository") != nil {
+			fn(n)
+			return
+		}
+		for i := 1; i < len(n.Content); i += 2 {
+			forEachImageRefNode(n.Content[i], fn)
+		}
+	case yamlv3.SequenceNode:
+		for _, c := range n.Content {
+			forEachImageRefNode(c, fn)
+		}
+	}
+}
+
+// nodeImageRef reads an image-ref mapping node into an ImageRef.
+func nodeImageRef(n *yamlv3.Node) wmanifest.ImageRef {
+	get := func(k string) string {
+		if v := mappingValue(n, k); v != nil {
+			return v.Value
+		}
+		return ""
+	}
+	return wmanifest.ImageRef{
+		Registry:   get("registry"),
+		Repository: get("repository"),
+		Tag:        get("tag"),
+		Digest:     get("digest"),
+	}
+}
+
+// setNodeMirrorRepo points an image-ref node at newRepo (already the full flattened
+// mirror repository) and drops any split-out registry key, so the operator resolves
+// it to exactly newRepo:<tag>.
+func setNodeMirrorRepo(n *yamlv3.Node, newRepo string) {
+	if v := mappingValue(n, "repository"); v != nil {
+		v.Value = newRepo
+		v.Tag = "!!str"
+		v.Style = 0
+	}
+	removeMappingKey(n, "registry")
+}
+
+// mappingValue returns the value node for key in a mapping node, or nil.
+func mappingValue(n *yamlv3.Node, key string) *yamlv3.Node {
+	if n == nil || n.Kind != yamlv3.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if n.Content[i].Value == key {
+			return n.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// removeMappingKey deletes key (and its value) from a mapping node if present.
+func removeMappingKey(n *yamlv3.Node, key string) {
+	if n == nil || n.Kind != yamlv3.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if n.Content[i].Value == key {
+			n.Content = append(n.Content[:i], n.Content[i+2:]...)
+			return
+		}
 	}
 }
 

--- a/cmd/wsm/registry_manifest.go
+++ b/cmd/wsm/registry_manifest.go
@@ -524,8 +524,7 @@ func mirrorImageRef(target string, ref wmanifest.ImageRef) string {
 // handles both image-ref encodings and preserves comments and fields wsm's pinned
 // struct doesn't model. mirrored maps an upstream GetImage("") to its mirror
 // repository; only refs present there are rewritten (so every rewrite was pushed),
-// and the rest are returned for the caller to warn on. Unchanged input is returned
-// as-is.
+// and the rest are returned for the caller to warn on.
 func rewriteManifestImages(data []byte, mirrored map[string]string) ([]byte, []string, error) {
 	var doc yamlv3.Node
 	if err := yamlv3.Unmarshal(data, &doc); err != nil {
@@ -582,8 +581,8 @@ func pruneMysqlExporter(root *yamlv3.Node) {
 	}
 }
 
-// forEachImageRefNode invokes fn on every mapping node that looks like an image
-// reference (has a "repository" key). It does not recurse into a matched node.
+// forEachImageRefNode calls fn on each image-ref mapping (one with a "repository"
+// key) without recursing into it.
 func forEachImageRefNode(n *yamlv3.Node, fn func(*yamlv3.Node)) {
 	switch n.Kind {
 	case yamlv3.DocumentNode:
@@ -605,7 +604,6 @@ func forEachImageRefNode(n *yamlv3.Node, fn func(*yamlv3.Node)) {
 	}
 }
 
-// nodeImageRef reads an image-ref mapping node into an ImageRef.
 func nodeImageRef(n *yamlv3.Node) wmanifest.ImageRef {
 	get := func(k string) string {
 		if v := mappingValue(n, k); v != nil {
@@ -621,9 +619,8 @@ func nodeImageRef(n *yamlv3.Node) wmanifest.ImageRef {
 	}
 }
 
-// setNodeMirrorRepo points an image-ref node at newRepo (already the full flattened
-// mirror repository) and drops any split-out registry key, so the operator resolves
-// it to exactly newRepo:<tag>.
+// setNodeMirrorRepo sets the repository to newRepo and removes any split-out registry
+// key, so the operator resolves the ref to exactly newRepo:<tag>.
 func setNodeMirrorRepo(n *yamlv3.Node, newRepo string) {
 	if v := mappingValue(n, "repository"); v != nil {
 		v.Value = newRepo
@@ -633,7 +630,6 @@ func setNodeMirrorRepo(n *yamlv3.Node, newRepo string) {
 	removeMappingKey(n, "registry")
 }
 
-// mappingValue returns the value node for key in a mapping node, or nil.
 func mappingValue(n *yamlv3.Node, key string) *yamlv3.Node {
 	if n == nil || n.Kind != yamlv3.MappingNode {
 		return nil
@@ -646,7 +642,6 @@ func mappingValue(n *yamlv3.Node, key string) *yamlv3.Node {
 	return nil
 }
 
-// removeMappingKey deletes key (and its value) from a mapping node if present.
 func removeMappingKey(n *yamlv3.Node, key string) {
 	if n == nil || n.Kind != yamlv3.MappingNode {
 		return

--- a/cmd/wsm/registry_manifest.go
+++ b/cmd/wsm/registry_manifest.go
@@ -56,7 +56,7 @@ const wandbPublicPrefix = "us-docker.pkg.dev/wandb-production/public/"
 func mirrorServerManifest(
 	ctx context.Context,
 	target, version, manifestSource string,
-	ex managedExclusions,
+	exclusions managedExclusions,
 	insecure, dryRun bool,
 	srcCtx, dstCtx *types.SystemContext,
 	policyCtx *signature.PolicyContext,
@@ -82,7 +82,7 @@ func mirrorServerManifest(
 		return fmt.Errorf("pull server manifest: %w", err)
 	}
 
-	refs, err := collectManifestImages(files, ex)
+	refs, err := collectManifestImages(files, exclusions)
 	if err != nil {
 		return fmt.Errorf("enumerate manifest images: %w", err)
 	}
@@ -90,19 +90,16 @@ func mirrorServerManifest(
 		return fmt.Errorf("server manifest %s:%s referenced no images", source, version)
 	}
 
-	// When mirroring the managed ClickHouse data-plane images, require the manifest
-	// to publish the Keeper image the operator would otherwise resolve from an
-	// internal constant wsm cannot see. Fail early with a clear message rather than
-	// producing an incomplete mirror. Skipped when ClickHouse is excluded.
-	if !ex.excludeServer("clickhouse") {
+	// Require the manifest to publish the ClickHouse Keeper image (see
+	// checkClickhouseKeeper); skipped when ClickHouse is excluded.
+	if !exclusions.excludeServer("clickhouse") {
 		if err := checkClickhouseKeeper(files); err != nil {
 			return err
 		}
 	}
 
-	// Map each unique upstream ref (by full source image) to its mirror
-	// repository once; the same mapping drives both image copying and the
-	// in-manifest rewrite so they cannot drift.
+	// One mapping from upstream ref to mirror repository drives both the image
+	// copy and the in-manifest rewrite, so they cannot drift.
 	mirrored := map[string]string{}
 	for _, ref := range refs {
 		mirrored[ref.GetImage("")] = rewriteRepoForMirror(target, upstreamRepo(ref))
@@ -353,14 +350,11 @@ func extractManifestYAML(ctx context.Context, fetcher content.Fetcher, desc ocis
 	}
 }
 
-// collectManifestImages parses each manifest YAML file and returns the unique
-// image references across applications (including init/sidecar containers) and
-// migration jobs, plus the managed data-plane images the operator reads from the
-// manifest's infra sections (object store, ClickHouse, MySQL, Redis, Kafka) — the
-// tier-3 images wsm used to hard-code. ex drops the data-plane images for excluded
-// managed types (Kafka is always included; it cannot be excluded). mirror and check
-// must pass the same ex so they agree on the set.
-func collectManifestImages(files map[string][]byte, ex managedExclusions) ([]wmanifest.ImageRef, error) {
+// collectManifestImages returns the unique images the manifest references: the W&B
+// application/migration images plus the managed data-plane images the operator reads
+// from the infra sections. exclusions drops the data-plane images for excluded types
+// (Kafka is always included). mirror and check must pass the same exclusions.
+func collectManifestImages(files map[string][]byte, exclusions managedExclusions) ([]wmanifest.ImageRef, error) {
 	seen := map[string]struct{}{}
 	var refs []wmanifest.ImageRef
 	add := func(ref wmanifest.ImageRef) {
@@ -393,21 +387,17 @@ func collectManifestImages(files map[string][]byte, ex managedExclusions) ([]wma
 		for _, mig := range m.Migrations {
 			add(mig.Image)
 		}
-		addInfraImages(m, add, ex)
+		addInfraImages(m, add, exclusions)
 	}
 	return refs, nil
 }
 
-// addInfraImages enumerates the managed data-plane images the operator pulls
-// straight from the manifest's infra sections. The MySQL "exporter" key is
-// deliberately skipped: moco exposes no per-cluster exporter-image override
-// (moco v0.34.0), so the operator ignores mysql.*.images.exporter and always
-// deploys the moco-chart exporter — mirroring the manifest value would push an
-// image that is never pulled. TODO: remove the skip once the manifest stops
-// emitting mysql.*.images.exporter. (The moco sidecars — agent/fluent-bit/the
-// real exporter — and every managed *operator* image are chart-derived, not
-// manifest-derived, so they are handled separately.)
-func addInfraImages(m wmanifest.Manifest, add func(wmanifest.ImageRef), ex managedExclusions) {
+// addInfraImages enumerates the managed data-plane images from the manifest's infra
+// sections. The MySQL "exporter" key is skipped: moco has no per-cluster
+// exporter-image override (v0.34.0), so the operator ignores it and deploys the
+// moco-chart exporter instead — mirroring the manifest value would push an unused
+// image. TODO: drop the skip once the manifest stops emitting it.
+func addInfraImages(m wmanifest.Manifest, add func(wmanifest.ImageRef), exclusions managedExclusions) {
 	addSection := func(cfgs map[string]wmanifest.InfraConfig, skipKeys map[string]bool) {
 		for _, inst := range sortedInstanceKeys(cfgs) {
 			images := cfgs[inst].Images
@@ -419,17 +409,17 @@ func addInfraImages(m wmanifest.Manifest, add func(wmanifest.ImageRef), ex manag
 			}
 		}
 	}
-	if !ex.excludeServer("object-store") {
+	if !exclusions.excludeServer("object-store") {
 		addSection(m.Bucket, nil)
 	}
-	if !ex.excludeServer("clickhouse") {
+	if !exclusions.excludeServer("clickhouse") {
 		addSection(m.Clickhouse, nil)
 		addSection(m.ClickhouseKeeper, nil)
 	}
-	if !ex.excludeServer("mysql") {
+	if !exclusions.excludeServer("mysql") {
 		addSection(m.Mysql, map[string]bool{"exporter": true})
 	}
-	if !ex.excludeServer("redis") {
+	if !exclusions.excludeServer("redis") {
 		addSection(m.Redis, nil)
 	}
 	// Kafka is always mirrored — it cannot be excluded.
@@ -467,14 +457,11 @@ func upstreamRepo(ref wmanifest.ImageRef) string {
 	return ref.Repository
 }
 
-// checkClickhouseKeeper rejects a manifest that deploys managed ClickHouse but
-// does not publish a Keeper image. Server manifests before ~0.84 left the
-// clickhouseKeeper section empty and the operator fell back to an internal
-// (unexported) constant wsm cannot read — so wsm could not mirror the Keeper image
-// the operator will actually pull. Requiring the image in the manifest keeps the
-// mirror complete; the fix is to mirror with W&B server >= 0.84.0. Values are
-// merged across every manifest file before deciding, since the two sections may
-// live in different files.
+// checkClickhouseKeeper rejects a manifest that deploys managed ClickHouse without a
+// Keeper image. Manifests before ~0.84 left clickhouseKeeper empty and the operator
+// fell back to an unexported constant wsm can't read, so wsm couldn't mirror the
+// Keeper image the operator pulls; the fix is W&B server >= 0.84.0. Sections are
+// merged across files since they may live in different ones.
 func checkClickhouseKeeper(files map[string][]byte) error {
 	hasServer, hasKeeper := false, false
 	for _, name := range sortedKeys(files) {
@@ -532,15 +519,13 @@ func mirrorImageRef(target string, ref wmanifest.ImageRef) string {
 	return mirrored.GetImage("")
 }
 
-// rewriteManifestImages rewrites every mirrored image reference in one manifest
-// YAML file to point at the mirror, and drops the inert MySQL exporter image. It
-// edits the YAML node tree rather than the raw bytes so it handles both image-ref
-// encodings (legacy embedded repository, and the newer registry/repository split)
-// and preserves comments and any fields wsm's pinned manifest struct does not
-// model. mirrored maps an upstream ref's GetImage("") to its flattened mirror
-// repository; only refs present there are rewritten, guaranteeing every rewritten
-// ref was actually pushed. Refs not in mirrored are left untouched and returned so
-// the caller can warn. Returns the original bytes unchanged when nothing matched.
+// rewriteManifestImages rewrites one manifest file's image refs to the mirror and
+// drops the inert MySQL exporter. It edits the YAML node tree (not raw bytes) so it
+// handles both image-ref encodings and preserves comments and fields wsm's pinned
+// struct doesn't model. mirrored maps an upstream GetImage("") to its mirror
+// repository; only refs present there are rewritten (so every rewrite was pushed),
+// and the rest are returned for the caller to warn on. Unchanged input is returned
+// as-is.
 func rewriteManifestImages(data []byte, mirrored map[string]string) ([]byte, []string, error) {
 	var doc yamlv3.Node
 	if err := yamlv3.Unmarshal(data, &doc); err != nil {

--- a/cmd/wsm/registry_manifest.go
+++ b/cmd/wsm/registry_manifest.go
@@ -56,7 +56,8 @@ const wandbPublicPrefix = "us-docker.pkg.dev/wandb-production/public/"
 func mirrorServerManifest(
 	ctx context.Context,
 	target, version, manifestSource string,
-	includeManaged, insecure, dryRun bool,
+	ex managedExclusions,
+	insecure, dryRun bool,
 	srcCtx, dstCtx *types.SystemContext,
 	policyCtx *signature.PolicyContext,
 ) error {
@@ -81,7 +82,7 @@ func mirrorServerManifest(
 		return fmt.Errorf("pull server manifest: %w", err)
 	}
 
-	refs, err := collectManifestImages(files, includeManaged)
+	refs, err := collectManifestImages(files, ex)
 	if err != nil {
 		return fmt.Errorf("enumerate manifest images: %w", err)
 	}
@@ -89,11 +90,11 @@ func mirrorServerManifest(
 		return fmt.Errorf("server manifest %s:%s referenced no images", source, version)
 	}
 
-	// When mirroring the managed data-plane images, require the manifest to
-	// publish the ones the operator would otherwise resolve from an internal
-	// constant wsm cannot see (ClickHouse Keeper). Fail early with a clear
-	// message rather than producing an incomplete mirror.
-	if includeManaged {
+	// When mirroring the managed ClickHouse data-plane images, require the manifest
+	// to publish the Keeper image the operator would otherwise resolve from an
+	// internal constant wsm cannot see. Fail early with a clear message rather than
+	// producing an incomplete mirror. Skipped when ClickHouse is excluded.
+	if !ex.excludeServer("clickhouse") {
 		if err := checkClickhouseKeeper(files); err != nil {
 			return err
 		}
@@ -354,12 +355,12 @@ func extractManifestYAML(ctx context.Context, fetcher content.Fetcher, desc ocis
 
 // collectManifestImages parses each manifest YAML file and returns the unique
 // image references across applications (including init/sidecar containers) and
-// migration jobs. When includeManaged is true it also enumerates the managed
-// data-plane images the operator reads from the manifest's infra sections
-// (object store, ClickHouse, MySQL, Redis, Kafka) — the tier-3 images wsm used
-// to hard-code. includeManaged should track --skip-managed-images so mirror and
-// check agree on the set.
-func collectManifestImages(files map[string][]byte, includeManaged bool) ([]wmanifest.ImageRef, error) {
+// migration jobs, plus the managed data-plane images the operator reads from the
+// manifest's infra sections (object store, ClickHouse, MySQL, Redis, Kafka) — the
+// tier-3 images wsm used to hard-code. ex drops the data-plane images for excluded
+// managed types (Kafka is always included; it cannot be excluded). mirror and check
+// must pass the same ex so they agree on the set.
+func collectManifestImages(files map[string][]byte, ex managedExclusions) ([]wmanifest.ImageRef, error) {
 	seen := map[string]struct{}{}
 	var refs []wmanifest.ImageRef
 	add := func(ref wmanifest.ImageRef) {
@@ -392,9 +393,7 @@ func collectManifestImages(files map[string][]byte, includeManaged bool) ([]wman
 		for _, mig := range m.Migrations {
 			add(mig.Image)
 		}
-		if includeManaged {
-			addInfraImages(m, add)
-		}
+		addInfraImages(m, add, ex)
 	}
 	return refs, nil
 }
@@ -408,23 +407,32 @@ func collectManifestImages(files map[string][]byte, includeManaged bool) ([]wman
 // emitting mysql.*.images.exporter. (The moco sidecars — agent/fluent-bit/the
 // real exporter — and every managed *operator* image are chart-derived, not
 // manifest-derived, so they are handled separately.)
-func addInfraImages(m wmanifest.Manifest, add func(wmanifest.ImageRef)) {
-	addSection := func(cfgs map[string]wmanifest.InfraConfig, skip map[string]bool) {
+func addInfraImages(m wmanifest.Manifest, add func(wmanifest.ImageRef), ex managedExclusions) {
+	addSection := func(cfgs map[string]wmanifest.InfraConfig, skipKeys map[string]bool) {
 		for _, inst := range sortedInstanceKeys(cfgs) {
 			images := cfgs[inst].Images
 			for _, key := range sortedImageKeys(images) {
-				if skip[key] {
+				if skipKeys[key] {
 					continue
 				}
 				add(images[key])
 			}
 		}
 	}
-	addSection(m.Bucket, nil)
-	addSection(m.Clickhouse, nil)
-	addSection(m.ClickhouseKeeper, nil)
-	addSection(m.Mysql, map[string]bool{"exporter": true})
-	addSection(m.Redis, nil)
+	if !ex.excludeServer("object-store") {
+		addSection(m.Bucket, nil)
+	}
+	if !ex.excludeServer("clickhouse") {
+		addSection(m.Clickhouse, nil)
+		addSection(m.ClickhouseKeeper, nil)
+	}
+	if !ex.excludeServer("mysql") {
+		addSection(m.Mysql, map[string]bool{"exporter": true})
+	}
+	if !ex.excludeServer("redis") {
+		addSection(m.Redis, nil)
+	}
+	// Kafka is always mirrored — it cannot be excluded.
 	for _, key := range sortedImageKeys(m.Kafka.Images) {
 		add(m.Kafka.Images[key])
 	}

--- a/cmd/wsm/registry_manifest_test.go
+++ b/cmd/wsm/registry_manifest_test.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	wmanifest "github.com/wandb/operator/pkg/wandb/manifest"
+	"sigs.k8s.io/yaml"
+)
+
+// A manifest fixture exercising both image-ref encodings: legacy embedded
+// (applications/migrations, registry baked into repository) and the newer
+// registry/repository split (infra sections), plus the inert mysql exporter.
+const testManifest = `
+applications:
+  anaconda2:
+    image:
+      repository: us-docker.pkg.dev/wandb-production/public/wandb/anaconda2
+      tag: "0.84.0"
+    containers:
+      - name: anaconda2
+  frontend:
+    image:
+      repository: us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx
+      tag: "0.84.0"
+migrations:
+  default:
+    image:
+      repository: us-docker.pkg.dev/wandb-production/public/wandb/migrations
+      tag: "0.84.0"
+bucket:
+  default:
+    images:
+      seaweedfs:
+        registry: docker.io
+        repository: chrislusf/seaweedfs
+        tag: "4.35"
+clickhouse:
+  default:
+    images:
+      server:
+        registry: docker.io
+        repository: altinity/clickhouse-server
+        tag: "25.8"
+clickhouseKeeper:
+  default:
+    images:
+      keeper:
+        registry: docker.io
+        repository: altinity/clickhouse-keeper
+        tag: "25.8"
+kafka:
+  images:
+    bufstream:
+      registry: us-docker.pkg.dev
+      repository: buf-images-1/buf/images/bufstream
+      tag: "0.4.15"
+    etcd:
+      registry: quay.io
+      repository: coreos/etcd
+      tag: "v3.5.31"
+    bucketEnsure:
+      repository: amazon/aws-cli
+      tag: "2.35.10"
+mysql:
+  default:
+    images:
+      mysql:
+        registry: ghcr.io
+        repository: cybozu-go/moco/mysql
+        tag: "8.4.8"
+      exporter:
+        registry: docker.io
+        repository: prom/mysqld-exporter
+        tag: "v0.15.1"
+redis:
+  default:
+    images:
+      standalone:
+        registry: quay.io
+        repository: opstree/redis
+        tag: "v7.0.15"
+`
+
+func imageSet(refs []wmanifest.ImageRef) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, r := range refs {
+		out[r.GetImage("")] = struct{}{}
+	}
+	return out
+}
+
+func TestCollectManifestImages_Managed(t *testing.T) {
+	files := map[string][]byte{"manifest.yaml": []byte(testManifest)}
+
+	refs, err := collectManifestImages(files, true)
+	if err != nil {
+		t.Fatalf("collectManifestImages: %v", err)
+	}
+	got := imageSet(refs)
+
+	want := []string{
+		"us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:0.84.0",
+		"us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:0.84.0",
+		"us-docker.pkg.dev/wandb-production/public/wandb/migrations:0.84.0",
+		"docker.io/chrislusf/seaweedfs:4.35",
+		"docker.io/altinity/clickhouse-server:25.8",
+		"docker.io/altinity/clickhouse-keeper:25.8",
+		"us-docker.pkg.dev/buf-images-1/buf/images/bufstream:0.4.15",
+		"quay.io/coreos/etcd:v3.5.31",
+		"amazon/aws-cli:2.35.10",
+		"ghcr.io/cybozu-go/moco/mysql:8.4.8",
+		"quay.io/opstree/redis:v7.0.15",
+	}
+	for _, w := range want {
+		if _, ok := got[w]; !ok {
+			t.Errorf("expected image %q not enumerated", w)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("image count = %d, want %d; got=%v", len(got), len(want), sortedSet(got))
+	}
+	// The inert mysql exporter must never be enumerated.
+	if _, ok := got["docker.io/prom/mysqld-exporter:v0.15.1"]; ok {
+		t.Errorf("mysql exporter image should be skipped, but was enumerated")
+	}
+}
+
+func TestCollectManifestImages_SkipManaged(t *testing.T) {
+	files := map[string][]byte{"manifest.yaml": []byte(testManifest)}
+
+	refs, err := collectManifestImages(files, false)
+	if err != nil {
+		t.Fatalf("collectManifestImages: %v", err)
+	}
+	got := imageSet(refs)
+	if len(got) != 3 {
+		t.Fatalf("skip-managed image count = %d, want 3 (apps+migrations only); got=%v", len(got), sortedSet(got))
+	}
+	for img := range got {
+		if !strings.Contains(img, "/wandb/") {
+			t.Errorf("skip-managed enumerated a non-app image: %q", img)
+		}
+	}
+}
+
+func TestRewriteManifestImages(t *testing.T) {
+	const target = "mirror.test"
+	files := map[string][]byte{"manifest.yaml": []byte(testManifest)}
+
+	refs, err := collectManifestImages(files, true)
+	if err != nil {
+		t.Fatalf("collectManifestImages: %v", err)
+	}
+	mirrored := map[string]string{}
+	for _, ref := range refs {
+		mirrored[ref.GetImage("")] = rewriteRepoForMirror(target, upstreamRepo(ref))
+	}
+
+	out, unknown, err := rewriteManifestImages([]byte(testManifest), mirrored)
+	if err != nil {
+		t.Fatalf("rewriteManifestImages: %v", err)
+	}
+	if len(unknown) != 0 {
+		t.Errorf("unexpected unknown refs left unrewritten: %v", unknown)
+	}
+
+	// Every upstream registry host must be gone — an air-gapped install must pull
+	// only from the mirror.
+	for _, host := range []string{"docker.io", "quay.io", "ghcr.io", "us-docker.pkg.dev"} {
+		if strings.Contains(string(out), host) {
+			t.Errorf("rewritten manifest still references upstream host %q:\n%s", host, out)
+		}
+	}
+	// The inert mysql exporter key must be dropped entirely.
+	if strings.Contains(string(out), "prom/mysqld-exporter") || strings.Contains(string(out), "exporter") {
+		t.Errorf("mysql exporter should be dropped from rewritten manifest:\n%s", out)
+	}
+
+	// Re-parse via the operator's own decoder and confirm every image now resolves
+	// to a mirror ref.
+	refs2, err := collectManifestImages(map[string][]byte{"manifest.yaml": out}, true)
+	if err != nil {
+		t.Fatalf("re-parse rewritten manifest: %v", err)
+	}
+	for _, r := range refs2 {
+		img := r.GetImage("")
+		if !strings.HasPrefix(img, target+"/") {
+			t.Errorf("rewritten image %q does not point at the mirror", img)
+		}
+	}
+	want := []string{
+		target + "/wandb/anaconda2:0.84.0",
+		target + "/altinity/clickhouse-server:25.8",
+		target + "/altinity/clickhouse-keeper:25.8",
+		target + "/buf-images-1/buf/images/bufstream:0.4.15",
+		target + "/amazon/aws-cli:2.35.10",
+		target + "/cybozu-go/moco/mysql:8.4.8",
+		target + "/opstree/redis:v7.0.15",
+	}
+	got := imageSet(refs2)
+	for _, w := range want {
+		if _, ok := got[w]; !ok {
+			t.Errorf("expected mirrored image %q missing; got=%v", w, sortedSet(got))
+		}
+	}
+}
+
+func TestCheckClickhouseKeeper(t *testing.T) {
+	// Fixture has clickhouse server + keeper → OK.
+	files := map[string][]byte{"manifest.yaml": []byte(testManifest)}
+	if err := checkClickhouseKeeper(files); err != nil {
+		t.Errorf("keeper present should pass, got: %v", err)
+	}
+
+	// Drop the keeper section → must error (0.83-style manifest).
+	var m map[string]interface{}
+	if err := yaml.Unmarshal([]byte(testManifest), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	delete(m, "clickhouseKeeper")
+	noKeeper, err := yaml.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := checkClickhouseKeeper(map[string][]byte{"manifest.yaml": noKeeper}); err == nil {
+		t.Errorf("expected error when clickhouse present without keeper image")
+	}
+
+	// No managed clickhouse at all → OK (nothing to require).
+	if err := checkClickhouseKeeper(map[string][]byte{"m.yaml": []byte("applications: {}\n")}); err != nil {
+		t.Errorf("no clickhouse should pass, got: %v", err)
+	}
+}
+
+func sortedSet(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/wsm/registry_manifest_test.go
+++ b/cmd/wsm/registry_manifest_test.go
@@ -83,7 +83,7 @@ redis:
         tag: "v7.0.15"
 `
 
-func mustExclusions(t *testing.T, ops, mgd []string, skip bool) managedExclusions {
+func mustExclude(t *testing.T, ops, mgd []string, skip bool) managedExclusions {
 	t.Helper()
 	exclusions, err := parseManagedExclusions(ops, mgd, skip)
 	if err != nil {
@@ -103,7 +103,7 @@ func imageSet(refs []wmanifest.ImageRef) map[string]struct{} {
 func TestCollectManifestImages_Managed(t *testing.T) {
 	files := map[string][]byte{"manifest.yaml": []byte(testManifest)}
 
-	refs, err := collectManifestImages(files, mustExclusions(t, nil, nil, false))
+	refs, err := collectManifestImages(files, mustExclude(t, nil, nil, false))
 	if err != nil {
 		t.Fatalf("collectManifestImages: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestCollectManifestImages_SkipManaged(t *testing.T) {
 	// --skip-managed-images excludes clickhouse/mysql/redis/object-store — but NOT
 	// kafka, which is always mirrored. So the set is app+migration images plus the
 	// kafka data-plane images.
-	refs, err := collectManifestImages(files, mustExclusions(t, nil, nil, true))
+	refs, err := collectManifestImages(files, mustExclude(t, nil, nil, true))
 	if err != nil {
 		t.Fatalf("collectManifestImages: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestCollectManifestImages_ExcludeOneType(t *testing.T) {
 	files := map[string][]byte{"manifest.yaml": []byte(testManifest)}
 
 	// --exclude-managed mysql drops the mysql server image but keeps everything else.
-	refs, err := collectManifestImages(files, mustExclusions(t, nil, []string{"mysql"}, false))
+	refs, err := collectManifestImages(files, mustExclude(t, nil, []string{"mysql"}, false))
 	if err != nil {
 		t.Fatalf("collectManifestImages: %v", err)
 	}
@@ -194,7 +194,7 @@ func TestCollectManifestImages_ExcludeOneType(t *testing.T) {
 
 	// --exclude-operators mysql is an operator-axis exclusion: it must NOT drop the
 	// mysql server image (still a managed service).
-	refs2, err := collectManifestImages(files, mustExclusions(t, []string{"mysql"}, nil, false))
+	refs2, err := collectManifestImages(files, mustExclude(t, []string{"mysql"}, nil, false))
 	if err != nil {
 		t.Fatalf("collectManifestImages: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestRewriteManifestImages(t *testing.T) {
 	const target = "mirror.test"
 	files := map[string][]byte{"manifest.yaml": []byte(testManifest)}
 
-	refs, err := collectManifestImages(files, mustExclusions(t, nil, nil, false))
+	refs, err := collectManifestImages(files, mustExclude(t, nil, nil, false))
 	if err != nil {
 		t.Fatalf("collectManifestImages: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestRewriteManifestImages(t *testing.T) {
 
 	// Re-parse via the operator's own decoder and confirm every image now resolves
 	// to a mirror ref.
-	refs2, err := collectManifestImages(map[string][]byte{"manifest.yaml": out}, mustExclusions(t, nil, nil, false))
+	refs2, err := collectManifestImages(map[string][]byte{"manifest.yaml": out}, mustExclude(t, nil, nil, false))
 	if err != nil {
 		t.Fatalf("re-parse rewritten manifest: %v", err)
 	}

--- a/cmd/wsm/registry_manifest_test.go
+++ b/cmd/wsm/registry_manifest_test.go
@@ -83,6 +83,15 @@ redis:
         tag: "v7.0.15"
 `
 
+func mustEx(t *testing.T, ops, mgd []string, skip bool) managedExclusions {
+	t.Helper()
+	ex, err := parseManagedExclusions(ops, mgd, skip)
+	if err != nil {
+		t.Fatalf("parseManagedExclusions(%v,%v,%v): %v", ops, mgd, skip, err)
+	}
+	return ex
+}
+
 func imageSet(refs []wmanifest.ImageRef) map[string]struct{} {
 	out := map[string]struct{}{}
 	for _, r := range refs {
@@ -94,7 +103,7 @@ func imageSet(refs []wmanifest.ImageRef) map[string]struct{} {
 func TestCollectManifestImages_Managed(t *testing.T) {
 	files := map[string][]byte{"manifest.yaml": []byte(testManifest)}
 
-	refs, err := collectManifestImages(files, true)
+	refs, err := collectManifestImages(files, mustEx(t, nil, nil, false))
 	if err != nil {
 		t.Fatalf("collectManifestImages: %v", err)
 	}
@@ -130,18 +139,67 @@ func TestCollectManifestImages_Managed(t *testing.T) {
 func TestCollectManifestImages_SkipManaged(t *testing.T) {
 	files := map[string][]byte{"manifest.yaml": []byte(testManifest)}
 
-	refs, err := collectManifestImages(files, false)
+	// --skip-managed-images excludes clickhouse/mysql/redis/object-store — but NOT
+	// kafka, which is always mirrored. So the set is app+migration images plus the
+	// kafka data-plane images.
+	refs, err := collectManifestImages(files, mustEx(t, nil, nil, true))
 	if err != nil {
 		t.Fatalf("collectManifestImages: %v", err)
 	}
 	got := imageSet(refs)
-	if len(got) != 3 {
-		t.Fatalf("skip-managed image count = %d, want 3 (apps+migrations only); got=%v", len(got), sortedSet(got))
+
+	wantPresent := []string{
+		"us-docker.pkg.dev/wandb-production/public/wandb/anaconda2:0.84.0",
+		"us-docker.pkg.dev/wandb-production/public/wandb/frontend-nginx:0.84.0",
+		"us-docker.pkg.dev/wandb-production/public/wandb/migrations:0.84.0",
+		"us-docker.pkg.dev/buf-images-1/buf/images/bufstream:0.4.15",
+		"quay.io/coreos/etcd:v3.5.31",
+		"amazon/aws-cli:2.35.10",
 	}
-	for img := range got {
-		if !strings.Contains(img, "/wandb/") {
-			t.Errorf("skip-managed enumerated a non-app image: %q", img)
+	for _, w := range wantPresent {
+		if _, ok := got[w]; !ok {
+			t.Errorf("expected %q present under skip-managed; got=%v", w, sortedSet(got))
 		}
+	}
+	// The excluded managed servers must be gone.
+	for _, bad := range []string{"clickhouse-server", "clickhouse-keeper", "opstree/redis", "moco/mysql", "seaweedfs"} {
+		for img := range got {
+			if strings.Contains(img, bad) {
+				t.Errorf("excluded managed image %q should be skipped", img)
+			}
+		}
+	}
+	if len(got) != len(wantPresent) {
+		t.Errorf("skip-managed image count = %d, want %d; got=%v", len(got), len(wantPresent), sortedSet(got))
+	}
+}
+
+func TestCollectManifestImages_ExcludeOneType(t *testing.T) {
+	files := map[string][]byte{"manifest.yaml": []byte(testManifest)}
+
+	// --exclude-managed mysql drops the mysql server image but keeps everything else.
+	refs, err := collectManifestImages(files, mustEx(t, nil, []string{"mysql"}, false))
+	if err != nil {
+		t.Fatalf("collectManifestImages: %v", err)
+	}
+	got := imageSet(refs)
+	if _, ok := got["ghcr.io/cybozu-go/moco/mysql:8.4.8"]; ok {
+		t.Errorf("mysql server image should be excluded")
+	}
+	for _, keep := range []string{"docker.io/altinity/clickhouse-server:25.8", "quay.io/opstree/redis:v7.0.15", "quay.io/coreos/etcd:v3.5.31"} {
+		if _, ok := got[keep]; !ok {
+			t.Errorf("non-excluded image %q should remain; got=%v", keep, sortedSet(got))
+		}
+	}
+
+	// --exclude-operators mysql is an operator-axis exclusion: it must NOT drop the
+	// mysql server image (still a managed service).
+	refs2, err := collectManifestImages(files, mustEx(t, []string{"mysql"}, nil, false))
+	if err != nil {
+		t.Fatalf("collectManifestImages: %v", err)
+	}
+	if _, ok := imageSet(refs2)["ghcr.io/cybozu-go/moco/mysql:8.4.8"]; !ok {
+		t.Errorf("--exclude-operators mysql must not drop the mysql server image")
 	}
 }
 
@@ -149,7 +207,7 @@ func TestRewriteManifestImages(t *testing.T) {
 	const target = "mirror.test"
 	files := map[string][]byte{"manifest.yaml": []byte(testManifest)}
 
-	refs, err := collectManifestImages(files, true)
+	refs, err := collectManifestImages(files, mustEx(t, nil, nil, false))
 	if err != nil {
 		t.Fatalf("collectManifestImages: %v", err)
 	}
@@ -173,14 +231,14 @@ func TestRewriteManifestImages(t *testing.T) {
 			t.Errorf("rewritten manifest still references upstream host %q:\n%s", host, out)
 		}
 	}
-	// The inert mysql exporter key must be dropped entirely.
-	if strings.Contains(string(out), "prom/mysqld-exporter") || strings.Contains(string(out), "exporter") {
+	// The inert mysql exporter must be dropped entirely.
+	if strings.Contains(string(out), "prom/mysqld-exporter") {
 		t.Errorf("mysql exporter should be dropped from rewritten manifest:\n%s", out)
 	}
 
 	// Re-parse via the operator's own decoder and confirm every image now resolves
 	// to a mirror ref.
-	refs2, err := collectManifestImages(map[string][]byte{"manifest.yaml": out}, true)
+	refs2, err := collectManifestImages(map[string][]byte{"manifest.yaml": out}, mustEx(t, nil, nil, false))
 	if err != nil {
 		t.Fatalf("re-parse rewritten manifest: %v", err)
 	}

--- a/cmd/wsm/registry_manifest_test.go
+++ b/cmd/wsm/registry_manifest_test.go
@@ -83,13 +83,13 @@ redis:
         tag: "v7.0.15"
 `
 
-func mustEx(t *testing.T, ops, mgd []string, skip bool) managedExclusions {
+func mustExclusions(t *testing.T, ops, mgd []string, skip bool) managedExclusions {
 	t.Helper()
-	ex, err := parseManagedExclusions(ops, mgd, skip)
+	exclusions, err := parseManagedExclusions(ops, mgd, skip)
 	if err != nil {
 		t.Fatalf("parseManagedExclusions(%v,%v,%v): %v", ops, mgd, skip, err)
 	}
-	return ex
+	return exclusions
 }
 
 func imageSet(refs []wmanifest.ImageRef) map[string]struct{} {
@@ -103,7 +103,7 @@ func imageSet(refs []wmanifest.ImageRef) map[string]struct{} {
 func TestCollectManifestImages_Managed(t *testing.T) {
 	files := map[string][]byte{"manifest.yaml": []byte(testManifest)}
 
-	refs, err := collectManifestImages(files, mustEx(t, nil, nil, false))
+	refs, err := collectManifestImages(files, mustExclusions(t, nil, nil, false))
 	if err != nil {
 		t.Fatalf("collectManifestImages: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestCollectManifestImages_SkipManaged(t *testing.T) {
 	// --skip-managed-images excludes clickhouse/mysql/redis/object-store — but NOT
 	// kafka, which is always mirrored. So the set is app+migration images plus the
 	// kafka data-plane images.
-	refs, err := collectManifestImages(files, mustEx(t, nil, nil, true))
+	refs, err := collectManifestImages(files, mustExclusions(t, nil, nil, true))
 	if err != nil {
 		t.Fatalf("collectManifestImages: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestCollectManifestImages_ExcludeOneType(t *testing.T) {
 	files := map[string][]byte{"manifest.yaml": []byte(testManifest)}
 
 	// --exclude-managed mysql drops the mysql server image but keeps everything else.
-	refs, err := collectManifestImages(files, mustEx(t, nil, []string{"mysql"}, false))
+	refs, err := collectManifestImages(files, mustExclusions(t, nil, []string{"mysql"}, false))
 	if err != nil {
 		t.Fatalf("collectManifestImages: %v", err)
 	}
@@ -194,7 +194,7 @@ func TestCollectManifestImages_ExcludeOneType(t *testing.T) {
 
 	// --exclude-operators mysql is an operator-axis exclusion: it must NOT drop the
 	// mysql server image (still a managed service).
-	refs2, err := collectManifestImages(files, mustEx(t, []string{"mysql"}, nil, false))
+	refs2, err := collectManifestImages(files, mustExclusions(t, []string{"mysql"}, nil, false))
 	if err != nil {
 		t.Fatalf("collectManifestImages: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestRewriteManifestImages(t *testing.T) {
 	const target = "mirror.test"
 	files := map[string][]byte{"manifest.yaml": []byte(testManifest)}
 
-	refs, err := collectManifestImages(files, mustEx(t, nil, nil, false))
+	refs, err := collectManifestImages(files, mustExclusions(t, nil, nil, false))
 	if err != nil {
 		t.Fatalf("collectManifestImages: %v", err)
 	}
@@ -238,7 +238,7 @@ func TestRewriteManifestImages(t *testing.T) {
 
 	// Re-parse via the operator's own decoder and confirm every image now resolves
 	// to a mirror ref.
-	refs2, err := collectManifestImages(map[string][]byte{"manifest.yaml": out}, mustEx(t, nil, nil, false))
+	refs2, err := collectManifestImages(map[string][]byte{"manifest.yaml": out}, mustExclusions(t, nil, nil, false))
 	if err != nil {
 		t.Fatalf("re-parse rewritten manifest: %v", err)
 	}

--- a/cmd/wsm/registry_mirror.go
+++ b/cmd/wsm/registry_mirror.go
@@ -63,29 +63,21 @@ external databases).`,
 			}
 			targetRegistry = strings.TrimRight(targetRegistry, "/")
 
-			ex, err := parseManagedExclusions(excludeOperators, excludeManaged, skipManaged)
+			exclusions, err := parseManagedExclusions(excludeOperators, excludeManaged, skipManaged)
 			if err != nil {
 				return err
 			}
 
 			ctx := context.Background()
 
-			// Render the charts from upstream (verified TLS) to learn the images to
-			// pull and push.
+			// Charts render from upstream (verified TLS); false = not from the mirror.
 			items, err := buildMirrorPlan(ctx, targetRegistry, operatorChartVersion, false, false)
 			if err != nil {
 				return err
 			}
-			// Managed MySQL/Redis/Kafka/ClickHouse/object-store services. The operator
-			// + sidecar images are derived by rendering the operator chart (from
-			// upstream, verified TLS); the data-plane server images come from the
-			// manifest below. Excluded types are dropped per --exclude-operators /
-			// --exclude-managed. These pull from docker.io/quay.io/ghcr.io and are
-			// pushed to the mirror. At install they're retargeted to the mirror by Helm
-			// image values set from --mirror-registry (see pkg/operator.DeployOperator),
-			// or on a plain-HTTP local install by the node's containerd registry mirrors
-			// (wsm cluster create --insecure-registry-host).
-			managed, err := buildManagedImagePlan(ctx, targetRegistry, operator.OperatorChartRepo, operatorChartVersion, ex, false)
+			// Managed-service operator + sidecar images (operator chart render) plus the
+			// data-plane server images (manifest below). Excluded types are dropped.
+			managed, err := buildManagedImagePlan(ctx, targetRegistry, operator.OperatorChartRepo, operatorChartVersion, exclusions, false)
 			if err != nil {
 				return err
 			}
@@ -133,7 +125,7 @@ external databases).`,
 			// (weave-trace, weave-python, local, console, migrations, …) are only
 			// mirrored when a version is given, since they're version-specific.
 			if wandbVersion != "" {
-				if err := mirrorServerManifest(ctx, targetRegistry, wandbVersion, manifestSource, ex, insecure, dryRun, srcCtx, dstCtx, policyCtx); err != nil {
+				if err := mirrorServerManifest(ctx, targetRegistry, wandbVersion, manifestSource, exclusions, insecure, dryRun, srcCtx, dstCtx, policyCtx); err != nil {
 					return err
 				}
 			} else {
@@ -166,17 +158,14 @@ type mirrorItem struct {
 }
 
 // buildMirrorPlan returns the OCI chart artifacts wsm mirrors plus the component
-// images each of the operator/cert-manager/nginx-gateway/kube-state-metrics charts
-// deploys. The chart artifacts (and the operator binary) are fixed refs keyed on
-// their pinned versions; the component images are derived by rendering each chart
-// so the set — and its image tags — always match what a real install pulls, with
-// no hand-maintained list (cert-manager's unused startupapicheck is dropped, and
-// the nginx data-plane image / cert-manager acmesolver are picked up).
+// images each chart (operator/cert-manager/nginx-gateway/kube-state-metrics) deploys.
+// Chart artifacts and the operator binary are fixed version-pinned refs; component
+// images are derived by rendering each chart, so the set always matches a real install
+// with no hand-maintained list.
 //
-// fromMirror selects where the tool charts are rendered from: false pulls them
-// from upstream (the mirror command), true pulls the copies already pushed under
-// target (the check command, which must work with registry access only). insecure
-// skips TLS verification for a self-signed mirror source.
+// fromMirror renders the tool charts from their pushed copies under target (for check,
+// which needs registry access only) instead of upstream (for mirror). insecure skips
+// TLS verification for a self-signed mirror source.
 func buildMirrorPlan(ctx context.Context, target, operatorChartVersion string, fromMirror, insecure bool) ([]mirrorItem, error) {
 	certManagerVersion := operator.CertManagerVersion
 	nginxGatewayVersion := operator.NginxGatewayVersion
@@ -206,10 +195,9 @@ func buildMirrorPlan(ctx context.Context, target, operatorChartVersion string, f
 		},
 	}
 
-	// Render each tool chart's images. pick chooses the upstream chart ref (mirror
-	// command) or its pushed copy under target (check command). The rendered image
-	// refs are upstream regardless of chart source, so they translate() to the same
-	// mirror destinations.
+	// pick selects the upstream chart ref (mirror) or its pushed copy under target
+	// (check); rendered image refs are upstream either way, so they translate() to
+	// the same mirror destinations.
 	pick := func(upstream, mirrored string) string {
 		if fromMirror {
 			return mirrored
@@ -238,29 +226,19 @@ func buildMirrorPlan(ctx context.Context, target, operatorChartVersion string, f
 	return plan, nil
 }
 
-// buildManagedImagePlan returns the managed-service images wsm mirrors that are
-// NOT derived from the server manifest: the bundled managed-service *operator*
-// images (moco/redis/seaweedfs/altinity) and the moco sidecars moco injects into
-// every managed MySQL pod (agent/fluent-bit/mysqld_exporter). These are derived by
-// rendering the operator chart client-side, so the set — and its versions — always
-// match what a real install pulls, with no hand-maintained list. (The tier-3
-// data-plane *server* images come from the manifest via collectManifestImages.)
-//
-// W&B's own images the render surfaces (the operator binary) are skipped here: they
-// live under the wandb-production/public prefix and are mirrored elsewhere with
-// W&B's path convention (the operator binary in buildMirrorPlan, application images
-// in the server manifest), which translate() would not reproduce.
-// chartRepo is the OCI repo base the operator chart is rendered from — upstream
-// (operator.OperatorChartRepo) when mirroring, or the mirror's own copy
-// ("oci://<host>/wandb/charts") when checking an air-gapped registry. ex drops the
-// operator images for excluded managed types (the operator chart is rendered with
-// those subcharts disabled). insecure skips TLS verification for a self-signed
-// mirror source.
-func buildManagedImagePlan(ctx context.Context, target, chartRepo, operatorChartVersion string, ex managedExclusions, insecure bool) ([]mirrorItem, error) {
-	if ex.allOperatorsExcluded() {
+// buildManagedImagePlan returns the managed-service operator + moco-sidecar images,
+// derived by rendering the operator chart so the set matches a real install with no
+// hand-maintained list. (The data-plane server images come from the manifest.)
+// chartRepo is the render source — upstream when mirroring, the mirror's own copy
+// when checking an air-gapped registry. exclusions drops excluded types' operator
+// images (their subcharts are disabled in the render). The W&B operator-binary image
+// is skipped: buildMirrorPlan mirrors it under W&B's path convention, which
+// translate() wouldn't reproduce. insecure skips TLS for a self-signed source.
+func buildManagedImagePlan(ctx context.Context, target, chartRepo, operatorChartVersion string, exclusions managedExclusions, insecure bool) ([]mirrorItem, error) {
+	if exclusions.allOperatorsExcluded() {
 		return nil, nil
 	}
-	imgs, err := operator.OperatorChartImages(ctx, chartRepo, operatorChartVersion, ex.disabledSubcharts(), insecure)
+	imgs, err := operator.OperatorChartImages(ctx, chartRepo, operatorChartVersion, exclusions.disabledSubcharts(), insecure)
 	if err != nil {
 		return nil, fmt.Errorf("derive operator chart images: %w", err)
 	}

--- a/cmd/wsm/registry_mirror.go
+++ b/cmd/wsm/registry_mirror.go
@@ -25,6 +25,8 @@ func registryMirrorCmd() *cobra.Command {
 		operatorChartVersion string
 		wandbVersion         string
 		skipManaged          bool
+		excludeOperators     []string
+		excludeManaged       []string
 		manifestSource       string
 	)
 
@@ -61,6 +63,11 @@ external databases).`,
 			}
 			targetRegistry = strings.TrimRight(targetRegistry, "/")
 
+			ex, err := parseManagedExclusions(excludeOperators, excludeManaged, skipManaged)
+			if err != nil {
+				return err
+			}
+
 			ctx := context.Background()
 
 			// Render the charts from upstream (verified TLS) to learn the images to
@@ -69,23 +76,20 @@ external databases).`,
 			if err != nil {
 				return err
 			}
-			if !skipManaged {
-				// Managed MySQL/Redis/Kafka/ClickHouse/object-store services. The
-				// operator + sidecar images are derived by rendering the operator
-				// chart; the data-plane server images come from the manifest below.
-				// These pull from docker.io/quay.io/ghcr.io and are pushed to the
-				// mirror. At install they're retargeted to the mirror by Helm image
-				// values set from --mirror-registry (see pkg/operator.DeployOperator),
-				// or on a plain-HTTP local install by the node's containerd registry
-				// mirrors (wsm cluster create --insecure-registry-host).
-				// Render the operator chart from upstream (always verified TLS) to
-				// learn the managed images to pull and push.
-				managed, err := buildManagedImagePlan(ctx, targetRegistry, operator.OperatorChartRepo, operatorChartVersion, false)
-				if err != nil {
-					return err
-				}
-				items = append(items, managed...)
+			// Managed MySQL/Redis/Kafka/ClickHouse/object-store services. The operator
+			// + sidecar images are derived by rendering the operator chart (from
+			// upstream, verified TLS); the data-plane server images come from the
+			// manifest below. Excluded types are dropped per --exclude-operators /
+			// --exclude-managed. These pull from docker.io/quay.io/ghcr.io and are
+			// pushed to the mirror. At install they're retargeted to the mirror by Helm
+			// image values set from --mirror-registry (see pkg/operator.DeployOperator),
+			// or on a plain-HTTP local install by the node's containerd registry mirrors
+			// (wsm cluster create --insecure-registry-host).
+			managed, err := buildManagedImagePlan(ctx, targetRegistry, operator.OperatorChartRepo, operatorChartVersion, ex, false)
+			if err != nil {
+				return err
 			}
+			items = append(items, managed...)
 
 			fmt.Printf("Mirroring %d artifacts to %s\n\n", len(items), targetRegistry)
 
@@ -129,7 +133,7 @@ external databases).`,
 			// (weave-trace, weave-python, local, console, migrations, …) are only
 			// mirrored when a version is given, since they're version-specific.
 			if wandbVersion != "" {
-				if err := mirrorServerManifest(ctx, targetRegistry, wandbVersion, manifestSource, !skipManaged, insecure, dryRun, srcCtx, dstCtx, policyCtx); err != nil {
+				if err := mirrorServerManifest(ctx, targetRegistry, wandbVersion, manifestSource, ex, insecure, dryRun, srcCtx, dstCtx, policyCtx); err != nil {
 					return err
 				}
 			} else {
@@ -145,7 +149,9 @@ external databases).`,
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Print the source → target mirroring plan without pushing")
 	cmd.Flags().StringVar(&operatorChartVersion, "operator-chart-version", "2.0.0-beta.3", "Operator chart version; also used as the tag for the operator binary image")
 	cmd.Flags().StringVar(&wandbVersion, "wandb-version", "", "W&B server version (e.g. 0.81.0); when set, also mirror the server manifest and every application image it references, rewriting them to point at the mirror")
-	cmd.Flags().BoolVar(&skipManaged, "skip-managed-images", false, "Don't mirror the managed-service operator + data-plane images (ClickHouse/Kafka/MySQL/Redis/object-store). Use when you run W&B against external databases.")
+	cmd.Flags().BoolVar(&skipManaged, "skip-managed-images", false, "Alias for --exclude-managed clickhouse,mysql,redis,object-store. Kafka is always mirrored.")
+	cmd.Flags().StringSliceVar(&excludeOperators, "exclude-operators", nil, "Managed types whose OPERATOR images to skip (you run your own cluster-wide operator), comma-separated: clickhouse,mysql,redis,object-store. The managed data-plane service is still mirrored.")
+	cmd.Flags().StringSliceVar(&excludeManaged, "exclude-managed", nil, "Managed types to skip ENTIRELY — operator AND data-plane images (you use an external service), comma-separated: clickhouse,mysql,redis,object-store. Kafka cannot be excluded.")
 	// TESTING ONLY, hidden from --help: pull the server manifest from a non-upstream
 	// OCI repo (e.g. a local Tilt registry serving unreleased wandb/core manifest
 	// changes) instead of us-docker.pkg.dev. Not a supported customer workflow.
@@ -246,10 +252,15 @@ func buildMirrorPlan(ctx context.Context, target, operatorChartVersion string, f
 // in the server manifest), which translate() would not reproduce.
 // chartRepo is the OCI repo base the operator chart is rendered from — upstream
 // (operator.OperatorChartRepo) when mirroring, or the mirror's own copy
-// ("oci://<host>/wandb/charts") when checking an air-gapped registry. insecure
-// skips TLS verification for a self-signed mirror source.
-func buildManagedImagePlan(ctx context.Context, target, chartRepo, operatorChartVersion string, insecure bool) ([]mirrorItem, error) {
-	imgs, err := operator.OperatorChartImages(ctx, chartRepo, operatorChartVersion, insecure)
+// ("oci://<host>/wandb/charts") when checking an air-gapped registry. ex drops the
+// operator images for excluded managed types (the operator chart is rendered with
+// those subcharts disabled). insecure skips TLS verification for a self-signed
+// mirror source.
+func buildManagedImagePlan(ctx context.Context, target, chartRepo, operatorChartVersion string, ex managedExclusions, insecure bool) ([]mirrorItem, error) {
+	if ex.allOperatorsExcluded() {
+		return nil, nil
+	}
+	imgs, err := operator.OperatorChartImages(ctx, chartRepo, operatorChartVersion, ex.disabledSubcharts(), insecure)
 	if err != nil {
 		return nil, fmt.Errorf("derive operator chart images: %w", err)
 	}

--- a/cmd/wsm/registry_mirror.go
+++ b/cmd/wsm/registry_mirror.go
@@ -61,17 +61,30 @@ external databases).`,
 			}
 			targetRegistry = strings.TrimRight(targetRegistry, "/")
 
-			items := buildMirrorPlan(targetRegistry, operatorChartVersion)
+			ctx := context.Background()
+
+			// Render the charts from upstream (verified TLS) to learn the images to
+			// pull and push.
+			items, err := buildMirrorPlan(ctx, targetRegistry, operatorChartVersion, false, false)
+			if err != nil {
+				return err
+			}
 			if !skipManaged {
-				// Managed MySQL/Redis/Kafka/ClickHouse/object-store services. These
-				// pull from docker.io/quay.io/ghcr.io and are pushed to provided registry mirror
-				// At install they're retargeted to the mirror by:
-				// Helm image values set from --mirror-registry using
-				// spec.global.imageRegistry on the CR, which the operator host-replaces
-				// (requires an operator version that declares the field). On a plain-HTTP local
-				// install without that field, the node's containerd registry mirrors
-				// (wsm cluster create --insecure-registry-host) redirect them instead.
-				items = append(items, buildManagedImagePlan(targetRegistry)...)
+				// Managed MySQL/Redis/Kafka/ClickHouse/object-store services. The
+				// operator + sidecar images are derived by rendering the operator
+				// chart; the data-plane server images come from the manifest below.
+				// These pull from docker.io/quay.io/ghcr.io and are pushed to the
+				// mirror. At install they're retargeted to the mirror by Helm image
+				// values set from --mirror-registry (see pkg/operator.DeployOperator),
+				// or on a plain-HTTP local install by the node's containerd registry
+				// mirrors (wsm cluster create --insecure-registry-host).
+				// Render the operator chart from upstream (always verified TLS) to
+				// learn the managed images to pull and push.
+				managed, err := buildManagedImagePlan(ctx, targetRegistry, operator.OperatorChartRepo, operatorChartVersion, false)
+				if err != nil {
+					return err
+				}
+				items = append(items, managed...)
 			}
 
 			fmt.Printf("Mirroring %d artifacts to %s\n\n", len(items), targetRegistry)
@@ -89,7 +102,6 @@ external databases).`,
 				dstCtx.OCIInsecureSkipTLSVerify = true
 			}
 
-			ctx := context.Background()
 			var pushed, failed int
 			for _, item := range items {
 				if dryRun {
@@ -117,7 +129,7 @@ external databases).`,
 			// (weave-trace, weave-python, local, console, migrations, …) are only
 			// mirrored when a version is given, since they're version-specific.
 			if wandbVersion != "" {
-				if err := mirrorServerManifest(ctx, targetRegistry, wandbVersion, manifestSource, insecure, dryRun, srcCtx, dstCtx, policyCtx); err != nil {
+				if err := mirrorServerManifest(ctx, targetRegistry, wandbVersion, manifestSource, !skipManaged, insecure, dryRun, srcCtx, dstCtx, policyCtx); err != nil {
 					return err
 				}
 			} else {
@@ -144,18 +156,28 @@ external databases).`,
 
 type mirrorItem struct {
 	src string // full upstream OCI reference, e.g. quay.io/jetstack/cert-manager-controller:v1.20.2
-	dst string // full target reference,  e.g. localhost:5000/jetstack/cert-manager-controller:v1.20.2
+	dst string // full target reference, e.g. localhost:5000/jetstack/cert-manager-controller:v1.20.2
 }
 
-// buildMirrorPlan returns the static set of artifacts Iteration 1 mirrors.
-// cert-manager and nginx-gateway versions come from pkg/operator so the
-// install side and mirror side stay in lockstep automatically.
-func buildMirrorPlan(target, operatorChartVersion string) []mirrorItem {
+// buildMirrorPlan returns the OCI chart artifacts wsm mirrors plus the component
+// images each of the operator/cert-manager/nginx-gateway/kube-state-metrics charts
+// deploys. The chart artifacts (and the operator binary) are fixed refs keyed on
+// their pinned versions; the component images are derived by rendering each chart
+// so the set — and its image tags — always match what a real install pulls, with
+// no hand-maintained list (cert-manager's unused startupapicheck is dropped, and
+// the nginx data-plane image / cert-manager acmesolver are picked up).
+//
+// fromMirror selects where the tool charts are rendered from: false pulls them
+// from upstream (the mirror command), true pulls the copies already pushed under
+// target (the check command, which must work with registry access only). insecure
+// skips TLS verification for a self-signed mirror source.
+func buildMirrorPlan(ctx context.Context, target, operatorChartVersion string, fromMirror, insecure bool) ([]mirrorItem, error) {
 	certManagerVersion := operator.CertManagerVersion
 	nginxGatewayVersion := operator.NginxGatewayVersion
+	ksmChartVersion := operator.KubeStateMetricsVersion
 
+	// OCI chart artifacts + the operator binary image (fixed refs, not rendered).
 	plan := []mirrorItem{
-		// Operator OCI chart + binary image
 		{
 			src: "us-docker.pkg.dev/wandb-production/public/wandb/charts/operator:" + operatorChartVersion,
 			dst: target + "/wandb/charts/operator:" + operatorChartVersion,
@@ -164,88 +186,82 @@ func buildMirrorPlan(target, operatorChartVersion string) []mirrorItem {
 			src: "us-docker.pkg.dev/wandb-production/public/wandb/operator:" + operatorChartVersion,
 			dst: target + "/wandb/operator:" + operatorChartVersion,
 		},
-
-		// cert-manager OCI chart
 		{
 			src: "quay.io/jetstack/charts/cert-manager:" + certManagerVersion,
 			dst: target + "/jetstack/charts/cert-manager:" + certManagerVersion,
 		},
-	}
-
-	for _, comp := range []string{"controller", "webhook", "cainjector", "acmesolver", "startupapicheck"} {
-		plan = append(plan, mirrorItem{
-			src: "quay.io/jetstack/cert-manager-" + comp + ":" + certManagerVersion,
-			dst: target + "/jetstack/cert-manager-" + comp + ":" + certManagerVersion,
-		})
-	}
-
-	// nginx-gateway-fabric chart + 2 images (control plane + data plane)
-	plan = append(plan,
-		mirrorItem{
+		{
 			src: "ghcr.io/nginx/charts/nginx-gateway-fabric:" + nginxGatewayVersion,
 			dst: target + "/nginx/charts/nginx-gateway-fabric:" + nginxGatewayVersion,
 		},
-		mirrorItem{
-			src: "ghcr.io/nginx/nginx-gateway-fabric:" + nginxGatewayVersion,
-			dst: target + "/nginx/nginx-gateway-fabric:" + nginxGatewayVersion,
-		},
-		mirrorItem{
-			src: "ghcr.io/nginx/nginx-gateway-fabric/nginx:" + nginxGatewayVersion,
-			dst: target + "/nginx/nginx-gateway-fabric/nginx:" + nginxGatewayVersion,
-		},
-	)
-
-	// kube-state-metrics chart + image. The install rewrites image.registry to the
-	// mirror host, keeping the repository path — so the image dst must match that.
-	ksmChartVersion := operator.KubeStateMetricsVersion
-	ksmImageTag := operator.KubeStateMetricsImageTag
-	plan = append(plan,
-		mirrorItem{
+		{
 			src: "ghcr.io/prometheus-community/charts/kube-state-metrics:" + ksmChartVersion,
 			dst: target + "/prometheus-community/charts/kube-state-metrics:" + ksmChartVersion,
 		},
-		mirrorItem{
-			src: "registry.k8s.io/kube-state-metrics/kube-state-metrics:" + ksmImageTag,
-			dst: target + "/kube-state-metrics/kube-state-metrics:" + ksmImageTag,
-		},
-	)
+	}
 
-	return plan
+	// Render each tool chart's images. pick chooses the upstream chart ref (mirror
+	// command) or its pushed copy under target (check command). The rendered image
+	// refs are upstream regardless of chart source, so they translate() to the same
+	// mirror destinations.
+	pick := func(upstream, mirrored string) string {
+		if fromMirror {
+			return mirrored
+		}
+		return upstream
+	}
+	toolCharts := []struct {
+		images   func(context.Context, string, bool) ([]string, error)
+		upstream string
+		mirrored string
+	}{
+		{operator.CertManagerImages, "oci://quay.io/jetstack/charts/cert-manager", "oci://" + target + "/jetstack/charts/cert-manager"},
+		{operator.NginxGatewayImages, "oci://ghcr.io/nginx/charts/nginx-gateway-fabric", "oci://" + target + "/nginx/charts/nginx-gateway-fabric"},
+		{operator.KubeStateMetricsImages, "oci://ghcr.io/prometheus-community/charts/kube-state-metrics", "oci://" + target + "/prometheus-community/charts/kube-state-metrics"},
+	}
+	for _, tc := range toolCharts {
+		imgs, err := tc.images(ctx, pick(tc.upstream, tc.mirrored), insecure)
+		if err != nil {
+			return nil, err
+		}
+		for _, img := range imgs {
+			plan = append(plan, mirrorItem{src: img, dst: translate(img, target)})
+		}
+	}
+
+	return plan, nil
 }
 
-func buildManagedImagePlan(target string) []mirrorItem {
-	images := []string{
-		// Tier 2 — subchart operator images (default-enabled subcharts).
-		"alpine/k8s:1.35.4", // altinity-clickhouse-operator.crdHook
-		"altinity/clickhouse-operator:0.26.3",
-		"altinity/metrics-exporter:0.26.3",
-		"chrislusf/seaweedfs-operator:1.0.21",
-		"ghcr.io/cybozu-go/moco:0.36.0",
-		"quay.io/opstree/redis-operator:v0.22.2",
-
-		// Tier 3 — data-plane server images.
-		"altinity/clickhouse-server:25.8.16.10002.altinitystable",
-		"altinity/clickhouse-keeper:25.8.16.10002.altinitystable",
-		// Kafka (Bufstream): broker + etcd + aws-cli bucket-ensure init image.
-		"us-docker.pkg.dev/buf-images-1/buf/images/bufstream:0.4.15",
-		"quay.io/coreos/etcd:v3.5.31",
-		"amazon/aws-cli:2.35.10",
-		// moco injects agent/fluent-bit/mysqld_exporter sidecars; all must be mirrored.
-		"ghcr.io/cybozu-go/moco/mysql:8.4.8",
-		"ghcr.io/cybozu-go/moco-agent:0.16.0",
-		"ghcr.io/cybozu-go/moco/fluent-bit:5.0.2.1",
-		"ghcr.io/cybozu-go/moco/mysqld_exporter:0.19.0.1",
-		"quay.io/opstree/redis:v7.0.15",
-		"quay.io/opstree/redis-sentinel:v7.0.12",
-		"quay.io/opstree/redis-exporter:v1.44.0",
-		"chrislusf/seaweedfs:4.35",
+// buildManagedImagePlan returns the managed-service images wsm mirrors that are
+// NOT derived from the server manifest: the bundled managed-service *operator*
+// images (moco/redis/seaweedfs/altinity) and the moco sidecars moco injects into
+// every managed MySQL pod (agent/fluent-bit/mysqld_exporter). These are derived by
+// rendering the operator chart client-side, so the set — and its versions — always
+// match what a real install pulls, with no hand-maintained list. (The tier-3
+// data-plane *server* images come from the manifest via collectManifestImages.)
+//
+// W&B's own images the render surfaces (the operator binary) are skipped here: they
+// live under the wandb-production/public prefix and are mirrored elsewhere with
+// W&B's path convention (the operator binary in buildMirrorPlan, application images
+// in the server manifest), which translate() would not reproduce.
+// chartRepo is the OCI repo base the operator chart is rendered from — upstream
+// (operator.OperatorChartRepo) when mirroring, or the mirror's own copy
+// ("oci://<host>/wandb/charts") when checking an air-gapped registry. insecure
+// skips TLS verification for a self-signed mirror source.
+func buildManagedImagePlan(ctx context.Context, target, chartRepo, operatorChartVersion string, insecure bool) ([]mirrorItem, error) {
+	imgs, err := operator.OperatorChartImages(ctx, chartRepo, operatorChartVersion, insecure)
+	if err != nil {
+		return nil, fmt.Errorf("derive operator chart images: %w", err)
 	}
 
-	plan := make([]mirrorItem, 0, len(images))
-	for _, img := range images {
+	plan := make([]mirrorItem, 0, len(imgs))
+	for _, img := range imgs {
+		if strings.HasPrefix(img, wandbPublicPrefix) {
+			continue
+		}
 		plan = append(plan, mirrorItem{src: img, dst: translate(img, target)})
 	}
-	return plan
+	return plan, nil
 }
 
 func mirrorOne(

--- a/docs/dev/registry-mirror-dehardcode-plan.md
+++ b/docs/dev/registry-mirror-dehardcode-plan.md
@@ -223,9 +223,20 @@ v0.34.0**:
   renders the tool charts from the mirror (air-gapped). Only the OCI **chart artifacts**
   and the operator binary remain fixed refs (version-pinned, not image lists). Covered by
   `pkg/operator/render_test.go`.
-- **Stage 3 — flags + consistency.** Add the §6 flags to mirror + check. Make mirror /
-  check / install call one derivation path. Add golden-image CI tests (see untracked
-  `pkg/operator/operator_test.go`) so drift fails CI, not customers.
+- **Stage 3 — scoping flags. ✅ DONE.** `cmd/wsm/registry_managed.go` adds the
+  `managedExclusions` model (two axes: `--exclude-operators` = operator images only;
+  `--exclude-managed` = operator + server images) with `parseManagedExclusions`
+  validating values and rejecting `kafka`/unknowns. `--skip-managed-images` is now an
+  alias for `--exclude-managed clickhouse,mysql,redis,object-store`. Exclusions thread
+  through the derivation: excluded operators disable their subchart in the operator-chart
+  render (dropping the operator image and, for moco, its sidecars); excluded managed
+  types skip their manifest infra sections; the keeper check is skipped when ClickHouse
+  is excluded. Flags added to both `mirror` and `check`. Verified end-to-end via dry-run
+  (`--exclude-managed mysql` drops moco+sidecars; `--exclude-operators clickhouse` drops
+  the altinity operator but keeps the manifest's clickhouse-server/keeper; `--exclude-*
+  kafka` errors). Tested in `registry_managed_test.go` + `registry_manifest_test.go`.
+  Kafka is always mirrored. Follow-up (not done): mirror matching `--set <subchart>.enabled=false`
+  toggles on `deploy-v2 operator` so a customer's install doesn't fight their own operator.
 - **Operator repo (separate PR):** raise the mysqld_exporter constraint (§7) and, if
   agreed, the keeper-const export.
 

--- a/docs/dev/registry-mirror-dehardcode-plan.md
+++ b/docs/dev/registry-mirror-dehardcode-plan.md
@@ -1,0 +1,243 @@
+# Plan: remove hard-coded image lists from `wsm registry mirror`
+
+**Goal:** stop hand-maintaining image lists in `cmd/wsm/registry_mirror.go`. Instead
+download the pinned **operator chart** and **server manifest**, parse them, and
+derive every image to mirror — and rewrite the manifest so an air-gapped install
+pulls **only** from the customer's private registry. Verified against operator
+chart `2.0.0-beta.3`, server manifests `0.83.0` / `0.84.0-daily.20`, operator
+source `../operator` (`v2.0.0-beta.3-9-geb182a5`), and moco `v0.34.0`.
+
+**Feasibility: mostly-derivable.** Two residuals need a decision (clickhouse-keeper
+on pre-0.84 manifests; the mysqld_exporter image, see §7).
+
+---
+
+## 1. What is hard-coded today
+
+Two lists in [`cmd/wsm/registry_mirror.go`](../../cmd/wsm/registry_mirror.go):
+`buildMirrorPlan` (operator/cert-manager/nginx/ksm charts + their images) and
+`buildManagedImagePlan` (~18 tier-2 operator + tier-3 data-plane images). A third,
+implicit copy of the mapping lives in `pkg/operator/operator.go` `InstallOperator`,
+which retargets each subchart image to the mirror via Helm values. Mirror, `check`,
+and install must all agree — today, by hand.
+
+`collectManifestImages` in `cmd/wsm/registry_manifest.go` already derives the W&B
+**application + migration** images and `mirrorServerManifest` rewrites those refs to
+the mirror. The plan extends both to the managed/infra images.
+
+## 2. The hand-maintained lists are already wrong (why derive)
+
+| Hard-coded | Reality | |
+|---|---|---|
+| `seaweedfs-operator:1.0.21` | chart renders **1.0.32** | stale |
+| `alpine/k8s:1.35.4` (altinity crdHook) | crdHook disabled by default; real image is `bitnami/kubectl`, never `alpine/k8s` | **phantom** |
+| keeper always mirrored | absent in 0.83.0 manifest, present in 0.84.0-daily.20 | version-dependent (§7) |
+| `moco/mysqld_exporter:0.19.0.1` vs manifest `prom/mysqld-exporter:v0.15.1` | operator deploys the moco-chart image; manifest field is **not honorable** by moco's CR API (§7) | needs a decision |
+
+## 3. Where each image comes from (verified)
+
+The operator reads **manifest** image refs for every managed data-plane component
+and resolves them through `ImageRef.GetImage(wandb.Spec.Global.ImageRegistry)`:
+
+- clickhouse server — `altinity/spec.go:247`; keeper — `keeper/spec.go:71` (+ unexported fallback const)
+- redis standalone/replication/sentinel/**exporter** — `redis/opstree/spec.go:188/353/274/229`
+- object store (seaweedfs) — `objectstore/seaweedfs/spec.go:136`
+- kafka bufstream + etcd — `kafka/bufstream/spec.go:553/345`; `bucketEnsure` (aws-cli) is the bucket-ensure init image
+- mysql server (moco/mysql) — `mysql/moco/spec.go:83/109`
+
+**Key mechanism — `GetImage(registry)` PREPENDS the global registry to the *full*
+upstream ref** (`manifest.go:112`): `{registry:"docker.io", repository:"altinity/clickhouse-server"}`
+→ `GetImage("mirror.io")` = `mirror.io/docker.io/altinity/clickhouse-server`. So
+`spec.global.imageRegistry` yields a **pull-through** layout (`<mirror>/<host>/<path>`),
+whereas wsm's push layout is **flattened** (`<mirror>/<path>`, host stripped by
+`translate`). That mismatch is exactly why wsm already rewrites app-image refs itself
+instead of relying on `global.imageRegistry`.
+
+The operator chart (`.../charts/operator:<ver>`) **bundles all subcharts** as
+`charts/*.tgz`, so a Helm v4 ClientOnly/DryRun render needs no cluster and no network
+beyond pulling the one chart. It yields the tier-2 **operator** images; the moco
+**sidecars** (`moco-agent`/`fluent-bit`/`mysqld_exporter`) appear only as moco-controller
+container **args** (`--agent-image` …) — invisible to a `container.Image` walk, but
+readable from args or from the bundled `charts/moco/values.yaml`.
+
+## 4. Decisions taken (from review) — the shape we're building
+
+1. **Rewrite ALL images in the manifest to the mirror** (not just app images), so an
+   air-gapped install pulls only from the private registry — no dependence on node
+   containerd registry-mirrors or on `spec.global.imageRegistry` being wired for every
+   code path. Flattened layout (`<mirror>/<path>`), consistent with today's app-image
+   rewrite. (Reverses the earlier "don't rewrite infra" note.)
+2. **Granular opt-out flags** so customers supplying their own managed services don't
+   mirror images they won't use (see §6).
+3. **mysqld_exporter should be manifest-driven** — but moco's CR API blocks the clean
+   version of this; see §7 for the constraint and options.
+
+## 5. Manifest rewrite — must handle BOTH `ImageRef` encodings
+
+The manifest mixes two encodings today and will until the migration to
+registry/repository completes — **the rewrite must support both**:
+
+- **Embedded** (legacy; today's app/migration images): `registry: ""`, host baked into
+  `repository` (e.g. `us-docker.pkg.dev/wandb-production/public/wandb/local`). This is
+  what today's byte-level `replaceRepo` / `rewriteRepoForMirror` handles.
+- **Split** (new; today's infra images): `registry: "docker.io"`,
+  `repository: "altinity/clickhouse-server"`. The current byte rewrite touches only the
+  `repository` substring, leaving `registry: "docker.io"` in place → broken
+  `docker.io/<mirror>/…` ref. **This is the gap to close.**
+
+One helper must map either encoding to the **same flattened mirror ref**
+(`<mirror>/<path>`, matching where wsm pushes via `translate`/`rewriteRepoForMirror` —
+which strips the host for generic images and the `wandb-production/public` prefix for
+W&B images). Recommended output: **normalize to** `registry: ""`,
+`repository: "<mirror>/<path>"`, so `GetImage("")` returns the mirror ref uniformly for
+both inputs and both current + future manifests.
+
+Recommended mechanism: a **typed round-trip** — wsm already imports the operator's
+`wmanifest.Manifest`, so unmarshal → rewrite every `ImageRef` (apps, initContainers,
+containers, migrations, and the infra `Images` maps) → marshal. The operator parses the
+same struct via `sigs.k8s.io/yaml`, so field order/comment loss is cosmetic and cannot
+change what it reads. **Leave `spec.global.imageRegistry` unset** for these so there's no
+double-prepend (§3).
+
+## 6. Scoping flags (Stage 3) — two independent axes
+
+Two orthogonal customer concerns, NOT one:
+- **Infra operators** (altinity-clickhouse, moco, redis-operator, seaweedfs) — a customer
+  may run their own cluster-wide installs of these, so wsm must be able to skip mirroring
+  the **operator** images.
+- **Managed infra servers** (clickhouse, mysql, redis, object-store) — a customer may
+  bring external DBs and never use W&B's managed infra, so skip those **server** images.
+
+So each type has **three states**: (1) full managed — operator + server (default);
+(2) BYO operator — server only; (3) not used — neither. Operator-exclusion is a *subset*
+of managed-exclusion (excluding the server implies excluding its now-purposeless operator;
+the reverse combo "server off / operator on" is meaningless).
+
+**Kafka CANNOT be excluded.** It is not a member of the excludable set at all — its
+images (bufstream/etcd/aws-cli, run directly by the wandb-operator; no subchart, no
+operator image) are **always** mirrored. `kafka` is not a valid value for either flag;
+passing it is a hard error, not a silent no-op. There is no code path that drops kafka.
+
+**Chosen design: Option B — two list flags** (over Option A's 8 booleans):
+- `--exclude-operators <list>` — skip only the operator images (BYO operator).
+- `--exclude-managed <list>` — skip operator **and** server images (external DB).
+
+Values: `clickhouse`, `mysql`, `redis`, `object-store`. `kafka`/unknown → error.
+`--exclude-managed X` implies operator X excluded (listing X in both is redundant-but-OK).
+`--skip-managed-images` becomes an alias for
+`--exclude-managed clickhouse,mysql,redis,object-store`.
+
+Why B over 8 booleans: the three states compose with no nonsensical combination, the
+operator-vs-managed distinction is explicit, and new infra types are just new allowed
+values — no new flags. Same flags on `registry check` (must compute the same set); and
+for install coherence, matching `--set <subchart>.enabled=false` toggles on
+`deploy-v2 operator` so a customer's real install doesn't fight their own operator.
+
+Value → images (operator images dropped by `--exclude-operators`; both by `--exclude-managed`):
+
+| Value | Operator images | Server images (manifest) |
+|---|---|---|
+| clickhouse | altinity-clickhouse-operator, altinity/metrics-exporter | clickhouse-server, clickhouse-keeper |
+| mysql | moco + agent/fluent-bit/mysqld_exporter sidecars¹ | moco/mysql |
+| redis | opstree redis-operator | opstree redis / sentinel / exporter |
+| object-store | seaweedfs-operator | seaweedfs |
+| kafka *(never excludable)* | — | bufstream, etcd, aws-cli (always mirrored) |
+
+¹ The moco sidecars are operator-injected and operator-versioned, so they ride with the
+mysql **operator** bucket — with BYO operator, the customer's own moco supplies them.
+
+## 7. The two residuals
+
+**clickhouse-keeper.** `keeper/spec.go` reads `ClickhouseKeeper[..].Images["keeper"]`
+and falls back to an **unexported** const `defaultKeeperImage` (`keeper/values.go:10`)
+when absent — which is the case for the plain 0.83.0 manifest, present in
+0.84.0-daily.20. Options: (a) require/recommend a manifest that populates keeper (0.84+);
+(b) guarded fallback = keeper repo at the `clickhouse-server` tag, with a warning;
+(c) upstream: export the const. The operator has a TODO to delete the const once all
+supported manifests supply keeper — so (a) is the direction.
+
+**mysqld_exporter — moco API constraint (new finding).** The intent "have the operator
+set the exporter image from the manifest" is **not achievable via moco's CR API in
+v0.34.0**:
+- Enabling telemetry sets `cluster.Spec.Collectors` (`mysql/moco/spec.go:96`), which makes
+  moco inject the exporter sidecar.
+- moco resolves that sidecar's image **only** from the controller-global
+  `--mysqld-exporter-image` flag (`moco/controllers/mysql_container.go:242`
+  `WithImage(r.ExporterImage)`), set once at controller start from the chart value.
+- The per-cluster override moco exposes, `OverwriteContainer`
+  (`moco/api/v1beta2/mysqlcluster_types.go:473`), carries only `Name`/`Resources`/
+  `SecurityContext` — **no image**. So the operator cannot honor
+  `mysql.<inst>.images.exporter` per-CR.
+
+**Decision:** the image the operator actually deploys is the moco-chart
+`ghcr.io/cybozu-go/moco/mysqld_exporter:0.19.0.1`, read from the moco-controller's
+`--mysqld-exporter-image` arg at chart-render time (§Stage 2). So:
+- **Source the exporter image from the chart render.** wsm parses the
+  `--mysqld-exporter-image` arg; if it is ever absent, fall back to the exported moco
+  const `moco.ExporterImage` (and warn) — the chart template has no `default`, so an
+  empty tag would render a malformed `repo:` rather than fall back.
+- **Explicitly ignore `mysql.<inst>.images.exporter` in the manifest** — it is inert
+  (moco has no per-CR exporter-image override, §above) and must not be mirrored. In the
+  §5 rewrite, **drop the `exporter` key** from the mysql `images` map so no dead upstream
+  ref lingers in the air-gapped manifest. This one small, *documented* skip is the only
+  manifest-specific special-case; tag it with a TODO to remove once the manifest stops
+  emitting the field.
+- **Going forward (operator/manifest side, separate):** the manifest will stop including
+  the mysql exporter image; at that point the skip above becomes a no-op and can be
+  deleted. (Optionally also raise an upstream moco request to allow a per-CR exporter
+  image, but that is not needed for this work.)
+
+## 8. Staged plan
+
+- **Stage 0 — centralize version inputs.** Hoist the duplicated
+  `operator-chart-version` default (`deploy_v2.go:530` + `registry_mirror.go:134`) to one
+  const; keep reusing the `pkg/operator` cert-manager/nginx/ksm consts.
+- **Stage 1 — derive tier-3 from the manifest + rewrite it. ✅ DONE.** `collectManifestImages`
+  now walks the infra `Images` maps (gated by `includeManaged`/`--skip-managed-images`) and
+  skips the `mysql.images.exporter` trap; the manifest rewrite is now yaml.v3 node-based,
+  registry-aware (both encodings, §5), drops the exporter key, and only rewrites pushed
+  refs (unknowns warned). `checkClickhouseKeeper` enforces §7(a). The manifest-derived
+  data-plane images were removed from `buildManagedImagePlan` (operator + moco-sidecar
+  images kept there pending Stage 2). `check` passes `!skipManaged` too. Covered by
+  `cmd/wsm/registry_manifest_test.go` and validated against the real 0.84.0-daily.20
+  manifest. Behavior change: data-plane images now require `--wandb-version` (they're
+  version-specific, read from that version's manifest).
+- **Stage 2a — derive operator + subchart + moco-sidecar images. ✅ DONE.**
+  `pkg/operator/render.go` renders the operator chart client-side (helm v4
+  `DryRunClient`, no cluster) and extracts images from workload containers,
+  initContainers, `--…-image` container args (the moco sidecars), CR image maps, and
+  hooks. `buildManagedImagePlan` now calls `operator.OperatorChartImages` instead of a
+  hard-coded list — fixing the `seaweedfs-operator` drift (→1.0.32) and dropping the
+  `alpine/k8s` phantom automatically. The operator binary (a W&B image) is filtered out
+  (mirrored by tier-1). `check` renders the chart **from the mirror**
+  (`oci://<host>/wandb/charts`, bundled subcharts travel with it) so it stays
+  air-gapped. Tested by `pkg/operator/render_test.go` (pure-extractor unit + real-chart
+  render).
+- **Stage 2b — derive cert-manager / nginx-gateway / kube-state-metrics images. ✅ DONE.**
+  `operator.CertManagerImages` / `NginxGatewayImages` / `KubeStateMetricsImages` render
+  each tool chart (with the same values install uses; a modern `KubeVersion` satisfies
+  the charts' `kubeVersion` floors). `buildMirrorPlan` now derives their component images
+  instead of hard-coding them — dropping the unused cert-manager `startupapicheck` (5→4),
+  and picking up the nginx NginxProxy data-plane image + cert-manager `acmesolver` arg.
+  `buildMirrorPlan` is now `ctx`-taking/fallible with a `fromMirror` switch so `check`
+  renders the tool charts from the mirror (air-gapped). Only the OCI **chart artifacts**
+  and the operator binary remain fixed refs (version-pinned, not image lists). Covered by
+  `pkg/operator/render_test.go`.
+- **Stage 3 — flags + consistency.** Add the §6 flags to mirror + check. Make mirror /
+  check / install call one derivation path. Add golden-image CI tests (see untracked
+  `pkg/operator/operator_test.go`) so drift fails CI, not customers.
+- **Operator repo (separate PR):** raise the mysqld_exporter constraint (§7) and, if
+  agreed, the keeper-const export.
+
+## 9. Risks / landmines
+
+1. **Extractor must exceed `container.Image`** — else it drops moco sidecars (args),
+   cert-manager acmesolver (`--acme-http01-solver-image` arg), startupapicheck / altinity
+   crdHook (`release.Hooks`), nginx data-plane (NginxProxy CR), seaweedfs (CRD defaults).
+2. **Value/toggle coupling** — render with the same values wsm installs with
+   (telemetry.mode, crdHook off, KSM only when telemetry=full, cert-manager
+   startupapicheck off, victoria/grafana gated). The §6 `--managed-*` flags drive this.
+3. **Registry-aware rewrite** (§5) — split-registry infra refs must have both fields
+   rewritten, and `spec.global.imageRegistry` left unset, or refs double-prepend/break.
+4. **Silent failures** — keeper fallback and any future operator-Go-only image produce no
+   compile/runtime signal; golden tests + explicit warnings are the mitigations.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -414,7 +414,7 @@ Pulls every chart and image required by `wsm deploy-v2 operator` from its upstre
 wsm registry mirror --to <host> [flags]
 ```
 
-Scope today: the operator OCI chart + binary image, cert-manager OCI chart + 5 component images, nginx-gateway-fabric OCI chart + 2 images (control plane + data plane). W&B server manifest, application images, and subchart controller images are upcoming iterations.
+Scope: the operator OCI chart + binary image, and the cert-manager, nginx-gateway-fabric, and kube-state-metrics OCI charts plus the component images each deploys. With `--wandb-version` it also mirrors the W&B server manifest and every image it references — the application images and the managed data-plane server images (ClickHouse/MySQL/Redis/Kafka/object-store) — and rewrites the manifest's image refs to point at your mirror. The managed-service **operator** images (moco/redis/seaweedfs/altinity) and their sidecars come with them. Nothing is hand-listed: the image sets are derived by rendering the charts and parsing the manifest, so they always match what an install actually pulls.
 
 #### Flags
 
@@ -424,6 +424,12 @@ Scope today: the operator OCI chart + binary image, cert-manager OCI chart + 5 c
 | `--insecure` | `false` | Skip TLS verification when pushing to the mirror. Use for plain-HTTP registries like a local `registry:2`. **Never** in production. |
 | `--dry-run` | `false` | Print the source → target mirroring plan without pushing. |
 | `--operator-chart-version` | `2.0.0-beta.3` | Operator chart version; also used as the tag for the operator binary image. Match this to the version you'll pass to `wsm deploy-v2 operator`. |
+| `--wandb-version` | — | W&B server version (e.g. `0.84.0`). When set, also mirror the server manifest and every application + managed data-plane image it references, rewriting them to point at the mirror. |
+| `--exclude-operators` | — | Comma-separated managed types (`clickhouse`, `mysql`, `redis`, `object-store`) whose **operator** images to skip — for when you run your own cluster-wide operator. The managed data-plane service is still mirrored. |
+| `--exclude-managed` | — | Comma-separated managed types to skip **entirely** — operator *and* data-plane images — for when you use an external service. `kafka` cannot be excluded. |
+| `--skip-managed-images` | `false` | Alias for `--exclude-managed clickhouse,mysql,redis,object-store`. Kafka is always mirrored. |
+
+The two exclusion flags cover independent cases: `--exclude-operators <type>` mirrors the managed data-plane service but not W&B's operator for it (you bring your own); `--exclude-managed <type>` skips the type completely (you bring an external service). Kafka is always mirrored and is not a valid value for either.
 
 Auth is read from your Docker config (`~/.docker/config.json`). Run `docker login <mirror-host>` before this command for any registry that requires credentials.
 
@@ -431,7 +437,7 @@ Auth is read from your Docker config (`~/.docker/config.json`). Run `docker logi
 
 Verifies that every artifact `wsm registry mirror` pushes is present in your mirror. It computes the **same destination set** as `mirror` (operator chart + image, cert-manager, nginx-gateway, the managed-service operator/data-plane images, and — with `--wandb-version` — the server manifest plus every application image it references), then does a manifest check for each.
 
-Pass the **same** `--operator-chart-version` / `--wandb-version` / `--skip-managed-images` you mirrored with, or `check` and `mirror` won't agree on the expected set. The server manifest and its application images are read back out of the mirror itself, so `check` works from an air-gapped host with access only to the registry.
+Pass the **same** `--operator-chart-version` / `--wandb-version` / `--exclude-operators` / `--exclude-managed` / `--skip-managed-images` you mirrored with, or `check` and `mirror` won't agree on the expected set. The server manifest and its application images are read back out of the mirror itself — and the charts are rendered from their copies in the mirror — so `check` works from an air-gapped host with access only to the registry.
 
 ```bash
 wsm registry check --registry <host> --wandb-version <version> [flags]
@@ -444,7 +450,9 @@ wsm registry check --registry <host> --wandb-version <version> [flags]
 | `--registry` | — | **Required.** Hostname of your mirror to check against. |
 | `--wandb-version` | — | W&B server version that was mirrored; when set, also check the server manifest and every application image it references. |
 | `--operator-chart-version` | `2.0.0-beta.3` | Operator chart version that was mirrored (must match `wsm registry mirror`). |
-| `--skip-managed-images` | `false` | Don't check the managed-service operator + data-plane images (match the flag you mirrored with). |
+| `--exclude-operators` | — | Managed types whose operator images to skip checking (match `--exclude-operators` you mirrored with). |
+| `--exclude-managed` | — | Managed types to skip checking entirely (match `--exclude-managed` you mirrored with). Kafka cannot be excluded. |
+| `--skip-managed-images` | `false` | Alias for `--exclude-managed clickhouse,mysql,redis,object-store` (match the flag you mirrored with). |
 | `--insecure` | `false` | Skip TLS verification when contacting the registry. |
 | `--fail-on-missing` | `false` | Exit non-zero if any artifact is missing. |
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -426,10 +426,10 @@ Scope: the operator OCI chart + binary image, and the cert-manager, nginx-gatewa
 | `--operator-chart-version` | `2.0.0-beta.3` | Operator chart version; also used as the tag for the operator binary image. Match this to the version you'll pass to `wsm deploy-v2 operator`. |
 | `--wandb-version` | — | W&B server version (e.g. `0.84.0`). When set, also mirror the server manifest and every application + managed data-plane image it references, rewriting them to point at the mirror. |
 | `--exclude-operators` | — | Comma-separated managed types (`clickhouse`, `mysql`, `redis`, `object-store`) whose **operator** images to skip — for when you run your own cluster-wide operator. The managed data-plane service is still mirrored. |
-| `--exclude-managed` | — | Comma-separated managed types to skip **entirely** — operator *and* data-plane images — for when you use an external service. `kafka` cannot be excluded. |
-| `--skip-managed-images` | `false` | Alias for `--exclude-managed clickhouse,mysql,redis,object-store`. Kafka is always mirrored. |
+| `--exclude-managed` | — | Comma-separated managed types to skip **entirely** — operator *and* data-plane images — for when you use an external service. |
+| `--skip-managed-images` | `false` | Alias for `--exclude-managed clickhouse,mysql,redis,object-store`. |
 
-The two exclusion flags cover independent cases: `--exclude-operators <type>` mirrors the managed data-plane service but not W&B's operator for it (you bring your own); `--exclude-managed <type>` skips the type completely (you bring an external service). Kafka is always mirrored and is not a valid value for either.
+The two exclusion flags cover independent cases: `--exclude-operators <type>` mirrors the managed data-plane service but not W&B's operator for it (you bring your own); `--exclude-managed <type>` skips the type completely (you bring an external service).
 
 Auth is read from your Docker config (`~/.docker/config.json`). Run `docker login <mirror-host>` before this command for any registry that requires credentials.
 
@@ -451,7 +451,7 @@ wsm registry check --registry <host> --wandb-version <version> [flags]
 | `--wandb-version` | — | W&B server version that was mirrored; when set, also check the server manifest and every application image it references. |
 | `--operator-chart-version` | `2.0.0-beta.3` | Operator chart version that was mirrored (must match `wsm registry mirror`). |
 | `--exclude-operators` | — | Managed types whose operator images to skip checking (match `--exclude-operators` you mirrored with). |
-| `--exclude-managed` | — | Managed types to skip checking entirely (match `--exclude-managed` you mirrored with). Kafka cannot be excluded. |
+| `--exclude-managed` | — | Managed types to skip checking entirely (match `--exclude-managed` you mirrored with). |
 | `--skip-managed-images` | `false` | Alias for `--exclude-managed clickhouse,mysql,redis,object-store` (match the flag you mirrored with). |
 | `--insecure` | `false` | Skip TLS verification when contacting the registry. |
 | `--fail-on-missing` | `false` | Exit non-zero if any artifact is missing. |

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -14,35 +14,20 @@ import (
 	"helm.sh/helm/v4/pkg/release"
 )
 
-// renderKubeVersion is the Kubernetes version the client-side render advertises.
-// It must satisfy the kubeVersion floors the charts declare (cert-manager needs
-// >=1.22, nginx-gateway-fabric >=1.31); the default client capabilities report an
-// old version and would fail the chart's kubeVersion check.
+// renderKubeVersion satisfies the charts' kubeVersion floors (cert-manager >=1.22,
+// nginx-gateway-fabric >=1.31); the default client capabilities report too old a version.
 const renderKubeVersion = "v1.33.0"
 
-// OperatorChartRepo is the public OCI repository base the operator chart is
-// published to. It matches DeployOperator's repositoryURL so the mirror and
-// install sides pull the same chart. The mirror command renders from here; the
-// check command renders the copy under a mirror's "oci://<host>/wandb/charts".
+// OperatorChartRepo is the public OCI repo base for the operator chart, matching
+// DeployOperator. The mirror renders from here; check renders the mirror's copy.
 const OperatorChartRepo = "oci://us-docker.pkg.dev/wandb-production/public/wandb/charts"
 
-// RenderChartImages pulls chartRef@version over verified TLS, renders it entirely
-// client-side (no cluster, no release), and returns every distinct container image
-// it would create, sorted. It looks beyond plain container images so it also
-// captures images the chart injects indirectly:
-//
-//   - workload container and initContainer images (image: <ref> scalars),
-//   - images passed to a container as a --…-image argument (moco's
-//     --agent-image/--fluent-bit-image/--mysqld-exporter-image, cert-manager's
-//     --acme-http01-solver-image),
-//   - image refs expressed as {registry?, repository, tag?/digest?} maps on custom
-//     resources (e.g. nginx-gateway-fabric's NginxProxy),
-//   - images in the chart's hook manifests.
-//
-// values are the Helm values to render with; pass the same ones the install side
-// uses (minus any mirror retargeting) so the derived set matches what a real
-// install pulls. insecure skips TLS verification (and allows plain HTTP) when
-// pulling the chart — used when rendering a chart copy from a self-signed mirror.
+// RenderChartImages renders chartRef@version client-side (no cluster) and returns the
+// sorted, de-duplicated container images it would create. Beyond plain container images
+// it captures init containers, images passed via --…-image args (moco sidecars,
+// cert-manager acmesolver), image refs on custom resources (e.g. NginxProxy), and hook
+// images. values should match the install (minus mirror retargeting); insecure allows a
+// self-signed / plain-HTTP chart source.
 func RenderChartImages(ctx context.Context, chartRef, version string, values map[string]any, insecure bool) ([]string, error) {
 	settings := cli.New()
 
@@ -62,17 +47,13 @@ func RenderChartImages(ctx context.Context, chartRef, version string, values map
 	}
 
 	inst := action.NewInstall(actionConfig)
-	// DryRunClient renders entirely client-side: no cluster contact, default
-	// capabilities.
-	inst.DryRunStrategy = action.DryRunClient
+	inst.DryRunStrategy = action.DryRunClient // render client-side, no cluster
 	inst.KubeVersion = kubeVersion
 	inst.Replace = true
 	inst.ReleaseName = "wsm-render"
 	inst.Namespace = "wsm-render"
 	inst.Version = version
-	// CRDs carry image strings as openAPIV3Schema defaults that are not
-	// necessarily pulled; rendering templates only keeps the set to images the
-	// chart actually deploys.
+	// Skip CRDs: their schema-default image strings aren't necessarily pulled.
 	inst.IncludeCRDs = false
 
 	cp, err := inst.LocateChart(chartRef, settings)
@@ -105,16 +86,11 @@ func RenderChartImages(ctx context.Context, chartRef, version string, values map
 	return extractImages(docs.String()), nil
 }
 
-// OperatorChartImages renders the wandb operator chart from chartRepo (an OCI repo
-// base — OperatorChartRepo for upstream, or a mirror's "oci://<host>/wandb/charts")
-// at chartVersion and returns the managed-service images it deploys: the operator
-// binary, the bundled managed-service operator images (moco/redis/seaweedfs/
-// altinity), and the moco sidecars injected via controller args. Rendered with the
-// same non-mirror values DeployOperator installs with, so the set matches a real
-// install. disabledSubcharts are managed-service operator subcharts to turn off
-// (via <name>.enabled=false) so their operator images — and, for moco, the injected
-// sidecars — are not derived; pass the subcharts for types the caller excludes.
-// insecure is passed through for a self-signed mirror source.
+// OperatorChartImages renders the operator chart from chartRepo at chartVersion and
+// returns the managed-service images it deploys (operator binary, the moco/redis/
+// seaweedfs/altinity operators, and the moco sidecars). disabledSubcharts turns off
+// subcharts (<name>.enabled=false) for excluded managed types so their images aren't
+// derived. Values match DeployOperator's non-mirror install.
 func OperatorChartImages(ctx context.Context, chartRepo, chartVersion string, disabledSubcharts []string, insecure bool) ([]string, error) {
 	values := map[string]any{
 		"wandb":          map[string]any{"install": false},
@@ -126,12 +102,9 @@ func OperatorChartImages(ctx context.Context, chartRepo, chartVersion string, di
 	return RenderChartImages(ctx, chartRepo+"/operator", chartVersion, values, insecure)
 }
 
-// CertManagerImages renders the cert-manager chart (at CertManagerVersion) from
-// chartRef and returns the component images it deploys. Rendered with the same
-// values InstallCertManager uses (startupapicheck disabled), so the derived set —
-// controller/webhook/cainjector plus the acmesolver passed via a controller arg —
-// matches what a real install pulls, and the unused startupapicheck image is not
-// mirrored.
+// CertManagerImages renders the cert-manager chart from chartRef with the same values
+// InstallCertManager uses (startupapicheck disabled), yielding controller/webhook/
+// cainjector plus the acmesolver passed via a controller arg.
 func CertManagerImages(ctx context.Context, chartRef string, insecure bool) ([]string, error) {
 	values := map[string]any{
 		"crds":            map[string]any{"enabled": true},
@@ -147,10 +120,8 @@ func NginxGatewayImages(ctx context.Context, chartRef string, insecure bool) ([]
 	return RenderChartImages(ctx, chartRef, NginxGatewayVersion, map[string]any{}, insecure)
 }
 
-// KubeStateMetricsImages renders the kube-state-metrics chart (at
-// KubeStateMetricsVersion) from chartRef and returns its image. The image tag is
-// pinned via the same value InstallKubeStateMetrics sets, so the derived image
-// matches the install even if the chart's default tag differs.
+// KubeStateMetricsImages renders the kube-state-metrics chart from chartRef. The tag
+// is pinned to match InstallKubeStateMetrics rather than the chart default.
 func KubeStateMetricsImages(ctx context.Context, chartRef string, insecure bool) ([]string, error) {
 	values := map[string]any{
 		"image": map[string]any{"tag": KubeStateMetricsImageTag},

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -155,7 +155,7 @@ func extractImages(manifests string) []string {
 		}
 		var node yamlv3.Node
 		if err := yamlv3.Unmarshal([]byte(doc), &node); err != nil {
-			continue // skip anything that isn't valid YAML
+			continue
 		}
 		walkImages(&node, add)
 	}
@@ -170,7 +170,7 @@ func walkImages(n *yamlv3.Node, add func(string)) {
 			walkImages(c, add)
 		}
 	case yamlv3.MappingNode:
-		// {registry?, repository, tag?/digest?} image-ref map (e.g. a CR's image).
+		// An image-ref map (e.g. a CR's image: {repository, tag}).
 		if repo := scalarChild(n, "repository"); repo != "" {
 			add(joinImageRef(scalarChild(n, "registry"), repo, scalarChild(n, "tag"), scalarChild(n, "digest")))
 		}
@@ -213,7 +213,6 @@ func addArgImages(seq *yamlv3.Node, add func(string)) {
 	}
 }
 
-// scalarChild returns the scalar value of key in a mapping node, or "".
 func scalarChild(n *yamlv3.Node, key string) string {
 	if n == nil || n.Kind != yamlv3.MappingNode {
 		return ""

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -111,11 +111,17 @@ func RenderChartImages(ctx context.Context, chartRef, version string, values map
 // binary, the bundled managed-service operator images (moco/redis/seaweedfs/
 // altinity), and the moco sidecars injected via controller args. Rendered with the
 // same non-mirror values DeployOperator installs with, so the set matches a real
-// install. insecure is passed through for a self-signed mirror source.
-func OperatorChartImages(ctx context.Context, chartRepo, chartVersion string, insecure bool) ([]string, error) {
+// install. disabledSubcharts are managed-service operator subcharts to turn off
+// (via <name>.enabled=false) so their operator images — and, for moco, the injected
+// sidecars — are not derived; pass the subcharts for types the caller excludes.
+// insecure is passed through for a self-signed mirror source.
+func OperatorChartImages(ctx context.Context, chartRepo, chartVersion string, disabledSubcharts []string, insecure bool) ([]string, error) {
 	values := map[string]any{
 		"wandb":          map[string]any{"install": false},
 		"wandb-operator": map[string]any{"image": map[string]any{"pullPolicy": "Always"}},
+	}
+	for _, sc := range disabledSubcharts {
+		values[sc] = map[string]any{"enabled": false}
 	}
 	return RenderChartImages(ctx, chartRepo+"/operator", chartVersion, values, insecure)
 }

--- a/pkg/operator/render.go
+++ b/pkg/operator/render.go
@@ -1,0 +1,265 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	yamlv3 "gopkg.in/yaml.v3"
+	"helm.sh/helm/v4/pkg/action"
+	"helm.sh/helm/v4/pkg/chart/common"
+	"helm.sh/helm/v4/pkg/chart/loader"
+	"helm.sh/helm/v4/pkg/cli"
+	"helm.sh/helm/v4/pkg/release"
+)
+
+// renderKubeVersion is the Kubernetes version the client-side render advertises.
+// It must satisfy the kubeVersion floors the charts declare (cert-manager needs
+// >=1.22, nginx-gateway-fabric >=1.31); the default client capabilities report an
+// old version and would fail the chart's kubeVersion check.
+const renderKubeVersion = "v1.33.0"
+
+// OperatorChartRepo is the public OCI repository base the operator chart is
+// published to. It matches DeployOperator's repositoryURL so the mirror and
+// install sides pull the same chart. The mirror command renders from here; the
+// check command renders the copy under a mirror's "oci://<host>/wandb/charts".
+const OperatorChartRepo = "oci://us-docker.pkg.dev/wandb-production/public/wandb/charts"
+
+// RenderChartImages pulls chartRef@version over verified TLS, renders it entirely
+// client-side (no cluster, no release), and returns every distinct container image
+// it would create, sorted. It looks beyond plain container images so it also
+// captures images the chart injects indirectly:
+//
+//   - workload container and initContainer images (image: <ref> scalars),
+//   - images passed to a container as a --…-image argument (moco's
+//     --agent-image/--fluent-bit-image/--mysqld-exporter-image, cert-manager's
+//     --acme-http01-solver-image),
+//   - image refs expressed as {registry?, repository, tag?/digest?} maps on custom
+//     resources (e.g. nginx-gateway-fabric's NginxProxy),
+//   - images in the chart's hook manifests.
+//
+// values are the Helm values to render with; pass the same ones the install side
+// uses (minus any mirror retargeting) so the derived set matches what a real
+// install pulls. insecure skips TLS verification (and allows plain HTTP) when
+// pulling the chart — used when rendering a chart copy from a self-signed mirror.
+func RenderChartImages(ctx context.Context, chartRef, version string, values map[string]any, insecure bool) ([]string, error) {
+	settings := cli.New()
+
+	actionConfig, err := initActionConfig(settings)
+	if err != nil {
+		return nil, fmt.Errorf("init helm action config: %w", err)
+	}
+	registryClient, err := newRegistryClient(settings, "", "", "", insecure, insecure)
+	if err != nil {
+		return nil, fmt.Errorf("create registry client: %w", err)
+	}
+	actionConfig.RegistryClient = registryClient
+
+	kubeVersion, err := common.ParseKubeVersion(renderKubeVersion)
+	if err != nil {
+		return nil, fmt.Errorf("parse kube version: %w", err)
+	}
+
+	inst := action.NewInstall(actionConfig)
+	// DryRunClient renders entirely client-side: no cluster contact, default
+	// capabilities.
+	inst.DryRunStrategy = action.DryRunClient
+	inst.KubeVersion = kubeVersion
+	inst.Replace = true
+	inst.ReleaseName = "wsm-render"
+	inst.Namespace = "wsm-render"
+	inst.Version = version
+	// CRDs carry image strings as openAPIV3Schema defaults that are not
+	// necessarily pulled; rendering templates only keeps the set to images the
+	// chart actually deploys.
+	inst.IncludeCRDs = false
+
+	cp, err := inst.LocateChart(chartRef, settings)
+	if err != nil {
+		return nil, fmt.Errorf("locate chart %q: %w", chartRef, err)
+	}
+	ch, err := loader.Load(cp)
+	if err != nil {
+		return nil, fmt.Errorf("load chart %q: %w", chartRef, err)
+	}
+	rel, err := inst.RunWithContext(ctx, ch, values)
+	if err != nil {
+		return nil, fmt.Errorf("render chart %q: %w", chartRef, err)
+	}
+
+	acc, err := release.NewAccessor(rel)
+	if err != nil {
+		return nil, fmt.Errorf("access rendered release: %w", err)
+	}
+	var docs strings.Builder
+	docs.WriteString(acc.Manifest())
+	for _, h := range acc.Hooks() {
+		ha, err := release.NewHookAccessor(h)
+		if err != nil {
+			continue
+		}
+		docs.WriteString("\n---\n")
+		docs.WriteString(ha.Manifest())
+	}
+	return extractImages(docs.String()), nil
+}
+
+// OperatorChartImages renders the wandb operator chart from chartRepo (an OCI repo
+// base — OperatorChartRepo for upstream, or a mirror's "oci://<host>/wandb/charts")
+// at chartVersion and returns the managed-service images it deploys: the operator
+// binary, the bundled managed-service operator images (moco/redis/seaweedfs/
+// altinity), and the moco sidecars injected via controller args. Rendered with the
+// same non-mirror values DeployOperator installs with, so the set matches a real
+// install. insecure is passed through for a self-signed mirror source.
+func OperatorChartImages(ctx context.Context, chartRepo, chartVersion string, insecure bool) ([]string, error) {
+	values := map[string]any{
+		"wandb":          map[string]any{"install": false},
+		"wandb-operator": map[string]any{"image": map[string]any{"pullPolicy": "Always"}},
+	}
+	return RenderChartImages(ctx, chartRepo+"/operator", chartVersion, values, insecure)
+}
+
+// CertManagerImages renders the cert-manager chart (at CertManagerVersion) from
+// chartRef and returns the component images it deploys. Rendered with the same
+// values InstallCertManager uses (startupapicheck disabled), so the derived set —
+// controller/webhook/cainjector plus the acmesolver passed via a controller arg —
+// matches what a real install pulls, and the unused startupapicheck image is not
+// mirrored.
+func CertManagerImages(ctx context.Context, chartRef string, insecure bool) ([]string, error) {
+	values := map[string]any{
+		"crds":            map[string]any{"enabled": true},
+		"startupapicheck": map[string]any{"enabled": false},
+	}
+	return RenderChartImages(ctx, chartRef, CertManagerVersion, values, insecure)
+}
+
+// NginxGatewayImages renders the nginx-gateway-fabric chart (at NginxGatewayVersion)
+// from chartRef and returns its images: the control-plane image and the data-plane
+// nginx image carried on the NginxProxy custom resource.
+func NginxGatewayImages(ctx context.Context, chartRef string, insecure bool) ([]string, error) {
+	return RenderChartImages(ctx, chartRef, NginxGatewayVersion, map[string]any{}, insecure)
+}
+
+// KubeStateMetricsImages renders the kube-state-metrics chart (at
+// KubeStateMetricsVersion) from chartRef and returns its image. The image tag is
+// pinned via the same value InstallKubeStateMetrics sets, so the derived image
+// matches the install even if the chart's default tag differs.
+func KubeStateMetricsImages(ctx context.Context, chartRef string, insecure bool) ([]string, error) {
+	values := map[string]any{
+		"image": map[string]any{"tag": KubeStateMetricsImageTag},
+	}
+	return RenderChartImages(ctx, chartRef, KubeStateMetricsVersion, values, insecure)
+}
+
+// extractImages parses a multi-document manifest string and returns the sorted,
+// de-duplicated set of container images it references. See RenderChartImages for
+// the forms it recognises.
+func extractImages(manifests string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	add := func(img string) {
+		img = strings.TrimSpace(img)
+		// Drop blanks, un-rendered template fragments, and anything that isn't a
+		// single token (a real image ref has no whitespace).
+		if img == "" || strings.Contains(img, "{{") || strings.ContainsAny(img, " \t\n\"'") {
+			return
+		}
+		if _, ok := seen[img]; ok {
+			return
+		}
+		seen[img] = struct{}{}
+		out = append(out, img)
+	}
+
+	for _, doc := range strings.Split(manifests, "\n---") {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		var node yamlv3.Node
+		if err := yamlv3.Unmarshal([]byte(doc), &node); err != nil {
+			continue // skip anything that isn't valid YAML
+		}
+		walkImages(&node, add)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func walkImages(n *yamlv3.Node, add func(string)) {
+	switch n.Kind {
+	case yamlv3.DocumentNode, yamlv3.SequenceNode:
+		for _, c := range n.Content {
+			walkImages(c, add)
+		}
+	case yamlv3.MappingNode:
+		// {registry?, repository, tag?/digest?} image-ref map (e.g. a CR's image).
+		if repo := scalarChild(n, "repository"); repo != "" {
+			add(joinImageRef(scalarChild(n, "registry"), repo, scalarChild(n, "tag"), scalarChild(n, "digest")))
+		}
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			key := n.Content[i].Value
+			val := n.Content[i+1]
+			switch {
+			case key == "image" && val.Kind == yamlv3.ScalarNode:
+				add(val.Value)
+			case (key == "args" || key == "command") && val.Kind == yamlv3.SequenceNode:
+				addArgImages(val, add)
+			}
+			walkImages(val, add)
+		}
+	}
+}
+
+// addArgImages scans a container args/command list for images passed via a
+// --…-image flag, in either "--foo-image=ref" or "--foo-image", "ref" form.
+func addArgImages(seq *yamlv3.Node, add func(string)) {
+	items := seq.Content
+	for i := 0; i < len(items); i++ {
+		if items[i].Kind != yamlv3.ScalarNode {
+			continue
+		}
+		s := items[i].Value
+		if !strings.HasPrefix(s, "--") {
+			continue
+		}
+		flag, val, hasEq := strings.Cut(strings.TrimPrefix(s, "--"), "=")
+		if !strings.HasSuffix(flag, "image") {
+			continue
+		}
+		if hasEq {
+			add(val)
+		} else if i+1 < len(items) && items[i+1].Kind == yamlv3.ScalarNode {
+			add(items[i+1].Value)
+			i++
+		}
+	}
+}
+
+// scalarChild returns the scalar value of key in a mapping node, or "".
+func scalarChild(n *yamlv3.Node, key string) string {
+	if n == nil || n.Kind != yamlv3.MappingNode {
+		return ""
+	}
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if n.Content[i].Value == key && n.Content[i+1].Kind == yamlv3.ScalarNode {
+			return n.Content[i+1].Value
+		}
+	}
+	return ""
+}
+
+func joinImageRef(registry, repository, tag, digest string) string {
+	img := repository
+	if registry != "" {
+		img = registry + "/" + repository
+	}
+	switch {
+	case digest != "":
+		return img + "@" + digest
+	case tag != "":
+		return img + ":" + tag
+	default:
+		return img
+	}
+}

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -1,0 +1,184 @@
+package operator
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// The extractor is pure and network-free: it must find images from container
+// image scalars, initContainers, {repository,tag} CR maps, and --…-image args in
+// both "--flag=val" and "--flag", "val" forms.
+func TestExtractImages(t *testing.T) {
+	const manifests = `
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: init
+          image: busybox:1.36
+      containers:
+        - name: controller
+          image: ghcr.io/cybozu-go/moco:0.36.0
+          args:
+            - --agent-image
+            - ghcr.io/cybozu-go/moco-agent:0.16.0
+            - --mysqld-exporter-image=ghcr.io/cybozu-go/moco/mysqld_exporter:0.19.0.1
+            - --zap-log-level=info
+---
+apiVersion: cert-manager.io/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: cm
+          image: quay.io/jetstack/cert-manager-controller:v1.20.2
+          args:
+            - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.20.2
+---
+apiVersion: gateway.nginx.org/v1alpha2
+kind: NginxProxy
+spec:
+  image:
+    repository: ghcr.io/nginx/nginx-gateway-fabric/nginx
+    tag: "2.5.1"
+`
+	got := map[string]bool{}
+	for _, i := range extractImages(manifests) {
+		got[i] = true
+	}
+	want := []string{
+		"busybox:1.36",
+		"ghcr.io/cybozu-go/moco:0.36.0",
+		"ghcr.io/cybozu-go/moco-agent:0.16.0",
+		"ghcr.io/cybozu-go/moco/mysqld_exporter:0.19.0.1",
+		"quay.io/jetstack/cert-manager-controller:v1.20.2",
+		"quay.io/jetstack/cert-manager-acmesolver:v1.20.2",
+		"ghcr.io/nginx/nginx-gateway-fabric/nginx:2.5.1",
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("expected image %q not extracted; got=%v", w, keys(got))
+		}
+	}
+	// A non-image flag value must not be mistaken for an image.
+	if got["info"] {
+		t.Errorf("--zap-log-level value leaked in as an image")
+	}
+	if len(got) != len(want) {
+		t.Errorf("extracted %d images, want %d: %v", len(got), len(want), keys(got))
+	}
+}
+
+// Network-dependent: renders the real operator chart. Skips if the registry is
+// unreachable so it never breaks offline/CI runs.
+func TestOperatorChartImages_Real(t *testing.T) {
+	imgs, err := OperatorChartImages(context.Background(), OperatorChartRepo, "2.0.0-beta.3", false)
+	if err != nil {
+		t.Skipf("cannot reach operator chart registry: %v", err)
+	}
+	got := map[string]bool{}
+	for _, i := range imgs {
+		got[i] = true
+	}
+	// Correct managed-operator + moco-sidecar set for 2.0.0-beta.3, including the
+	// drift fix (seaweedfs-operator 1.0.32, not the old hard-coded 1.0.21).
+	want := []string{
+		"altinity/clickhouse-operator:0.26.3",
+		"altinity/metrics-exporter:0.26.3",
+		"chrislusf/seaweedfs-operator:1.0.32",
+		"ghcr.io/cybozu-go/moco:0.36.0",
+		"ghcr.io/cybozu-go/moco-agent:0.16.0",
+		"ghcr.io/cybozu-go/moco/fluent-bit:5.0.2.1",
+		"ghcr.io/cybozu-go/moco/mysqld_exporter:0.19.0.1",
+		"quay.io/opstree/redis-operator:v0.22.2",
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("expected rendered image %q missing; got=%v", w, keys(got))
+		}
+	}
+	// The alpine/k8s crdHook image is a phantom (hook disabled by default) and must
+	// not be derived.
+	for i := range got {
+		if strings.HasPrefix(i, "alpine/k8s") {
+			t.Errorf("phantom image %q should not be derived", i)
+		}
+	}
+}
+
+// Network-dependent: renders the three tool charts. Skips if unreachable.
+func TestToolChartImages_Real(t *testing.T) {
+	ctx := context.Background()
+	cases := []struct {
+		name string
+		fn   func(context.Context, string, bool) ([]string, error)
+		ref  string
+		want []string
+		// absent must not appear (cert-manager's startupapicheck is disabled).
+		absent string
+	}{
+		{
+			name: "cert-manager",
+			fn:   CertManagerImages,
+			ref:  "oci://quay.io/jetstack/charts/cert-manager",
+			want: []string{
+				"quay.io/jetstack/cert-manager-controller:" + CertManagerVersion,
+				"quay.io/jetstack/cert-manager-webhook:" + CertManagerVersion,
+				"quay.io/jetstack/cert-manager-cainjector:" + CertManagerVersion,
+				"quay.io/jetstack/cert-manager-acmesolver:" + CertManagerVersion,
+			},
+			absent: "cert-manager-startupapicheck",
+		},
+		{
+			name: "nginx-gateway",
+			fn:   NginxGatewayImages,
+			ref:  "oci://ghcr.io/nginx/charts/nginx-gateway-fabric",
+			want: []string{
+				"ghcr.io/nginx/nginx-gateway-fabric:" + NginxGatewayVersion,
+				"ghcr.io/nginx/nginx-gateway-fabric/nginx:" + NginxGatewayVersion,
+			},
+		},
+		{
+			name: "kube-state-metrics",
+			fn:   KubeStateMetricsImages,
+			ref:  "oci://ghcr.io/prometheus-community/charts/kube-state-metrics",
+			want: []string{
+				"registry.k8s.io/kube-state-metrics/kube-state-metrics:" + KubeStateMetricsImageTag,
+			},
+		},
+	}
+	for _, c := range cases {
+		imgs, err := c.fn(ctx, c.ref, false)
+		if err != nil {
+			t.Skipf("%s: cannot reach registry: %v", c.name, err)
+		}
+		got := map[string]bool{}
+		for _, i := range imgs {
+			got[i] = true
+		}
+		for _, w := range c.want {
+			if !got[w] {
+				t.Errorf("%s: expected image %q missing; got=%v", c.name, w, keys(got))
+			}
+		}
+		if c.absent != "" {
+			for i := range got {
+				if strings.Contains(i, c.absent) {
+					t.Errorf("%s: image %q should not be derived", c.name, i)
+				}
+			}
+		}
+	}
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/operator/render_test.go
+++ b/pkg/operator/render_test.go
@@ -76,7 +76,7 @@ spec:
 // Network-dependent: renders the real operator chart. Skips if the registry is
 // unreachable so it never breaks offline/CI runs.
 func TestOperatorChartImages_Real(t *testing.T) {
-	imgs, err := OperatorChartImages(context.Background(), OperatorChartRepo, "2.0.0-beta.3", false)
+	imgs, err := OperatorChartImages(context.Background(), OperatorChartRepo, "2.0.0-beta.3", nil, false)
 	if err != nil {
 		t.Skipf("cannot reach operator chart registry: %v", err)
 	}


### PR DESCRIPTION
Some images are currently hardcoded in wsm and are not updated when changes happen upstream:

- Move all chart and manifest defined images to be read from the upstream.  
- Rewrite all images in the manifest for consistency, and remove the need to set the ImageRegistry override in the CR, only the manifest override is needed.
- Add flags to remove managed infra images from the mirroring if they are not desired

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added granular exclusions for operators and managed services when mirroring or validating registries.
  * Added automatic image discovery from rendered charts and server manifests.
  * Registry checks now support registry-only validation and use the same image planning as mirroring.
* **Bug Fixes**
  * Improved manifest image rewriting across supported image-reference formats.
  * Added handling for required Kafka and ClickHouse Keeper images and omitted inactive exporter images.
  * Added validation for unsupported or unknown exclusion types.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->